### PR TITLE
Merge account management into 1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: VentExpensePro CI
+
+on:
+  pull_request:
+    branches:
+      - master
+      - staging
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: '3.27.1' # Matching potential local version or using stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Verify formatting
+        run: dart format --output=none --set-exit-if-changed .
+
+      - name: Analyze project source
+        run: flutter analyze
+
+      - name: Run tests
+        run: flutter test

--- a/lib/core/di/service_locator.dart
+++ b/lib/core/di/service_locator.dart
@@ -17,27 +17,20 @@ final sl = GetIt.instance;
 /// Registers all dependencies. Call once at app startup.
 Future<void> initServiceLocator() async {
   // — Repositories —
-  sl.registerLazySingleton<AccountRepository>(
-    () => AccountRepositoryImpl(),
-  );
+  sl.registerLazySingleton<AccountRepository>(() => AccountRepositoryImpl());
   sl.registerLazySingleton<TransactionRepository>(
     () => TransactionRepositoryImpl(),
   );
-  sl.registerLazySingleton<CategoryRepository>(
-    () => CategoryRepositoryImpl(),
-  );
+  sl.registerLazySingleton<CategoryRepository>(() => CategoryRepositoryImpl());
 
   // — Use Cases —
-  sl.registerFactory(
-    () => CalculateNetPosition(sl<AccountRepository>()),
-  );
+  sl.registerFactory(() => CalculateNetPosition(sl<AccountRepository>()));
   sl.registerFactory(
     () => LogTransaction(sl<TransactionRepository>(), sl<AccountRepository>()),
   );
   sl.registerFactory(
-    () => SettleCreditBill(sl<TransactionRepository>(), sl<AccountRepository>()),
+    () =>
+        SettleCreditBill(sl<TransactionRepository>(), sl<AccountRepository>()),
   );
-  sl.registerFactory(
-    () => ManageAccount(sl<AccountRepository>()),
-  );
+  sl.registerFactory(() => ManageAccount(sl<AccountRepository>()));
 }

--- a/lib/core/di/service_locator.dart
+++ b/lib/core/di/service_locator.dart
@@ -8,6 +8,7 @@ import '../../domain/repositories/category_repository.dart';
 import '../../domain/repositories/transaction_repository.dart';
 import '../../domain/usecases/calculate_net_position.dart';
 import '../../domain/usecases/log_transaction.dart';
+import '../../domain/usecases/manage_account.dart';
 import '../../domain/usecases/settle_credit_bill.dart';
 
 /// Global service locator instance.
@@ -35,5 +36,8 @@ Future<void> initServiceLocator() async {
   );
   sl.registerFactory(
     () => SettleCreditBill(sl<TransactionRepository>(), sl<AccountRepository>()),
+  );
+  sl.registerFactory(
+    () => ManageAccount(sl<AccountRepository>()),
   );
 }

--- a/lib/core/utils/date_formatter.dart
+++ b/lib/core/utils/date_formatter.dart
@@ -5,20 +5,16 @@ class DateFormatter {
   DateFormatter._();
 
   /// Full date: "21 February 2026"
-  static String full(DateTime date) =>
-      DateFormat('d MMMM yyyy').format(date);
+  static String full(DateTime date) => DateFormat('d MMMM yyyy').format(date);
 
   /// Short date: "21 Feb 2026"
-  static String short(DateTime date) =>
-      DateFormat('d MMM yyyy').format(date);
+  static String short(DateTime date) => DateFormat('d MMM yyyy').format(date);
 
   /// Day and month only: "21 Feb"
-  static String dayMonth(DateTime date) =>
-      DateFormat('d MMM').format(date);
+  static String dayMonth(DateTime date) => DateFormat('d MMM').format(date);
 
   /// Time only: "14:30"
-  static String time(DateTime date) =>
-      DateFormat('HH:mm').format(date);
+  static String time(DateTime date) => DateFormat('HH:mm').format(date);
 
   /// Relative day label: "Today", "Yesterday", or short date.
   static String relative(DateTime date) {

--- a/lib/data/datasources/local_database.dart
+++ b/lib/data/datasources/local_database.dart
@@ -18,11 +18,7 @@ class LocalDatabase {
     final dbPath = await getDatabasesPath();
     final path = '$dbPath/$_dbName';
 
-    return openDatabase(
-      path,
-      version: _dbVersion,
-      onCreate: _onCreate,
-    );
+    return openDatabase(path, version: _dbVersion, onCreate: _onCreate);
   }
 
   static Future<void> _onCreate(Database db, int version) async {
@@ -75,14 +71,39 @@ class LocalDatabase {
   static Future<void> _seedCategories(Database db) async {
     const defaults = [
       {'id': 'food', 'name': 'Food', 'icon': 'food', 'is_custom': 0},
-      {'id': 'transport', 'name': 'Transport', 'icon': 'transport', 'is_custom': 0},
+      {
+        'id': 'transport',
+        'name': 'Transport',
+        'icon': 'transport',
+        'is_custom': 0,
+      },
       {'id': 'bills', 'name': 'Bills', 'icon': 'bills', 'is_custom': 0},
-      {'id': 'shopping', 'name': 'Shopping', 'icon': 'shopping', 'is_custom': 0},
-      {'id': 'entertainment', 'name': 'Entertainment', 'icon': 'entertainment', 'is_custom': 0},
+      {
+        'id': 'shopping',
+        'name': 'Shopping',
+        'icon': 'shopping',
+        'is_custom': 0,
+      },
+      {
+        'id': 'entertainment',
+        'name': 'Entertainment',
+        'icon': 'entertainment',
+        'is_custom': 0,
+      },
       {'id': 'health', 'name': 'Health', 'icon': 'health', 'is_custom': 0},
-      {'id': 'education', 'name': 'Education', 'icon': 'education', 'is_custom': 0},
+      {
+        'id': 'education',
+        'name': 'Education',
+        'icon': 'education',
+        'is_custom': 0,
+      },
       {'id': 'other', 'name': 'Other', 'icon': 'other', 'is_custom': 0},
-      {'id': 'settlement', 'name': 'Settlement', 'icon': 'settlement', 'is_custom': 0},
+      {
+        'id': 'settlement',
+        'name': 'Settlement',
+        'icon': 'settlement',
+        'is_custom': 0,
+      },
     ];
 
     final batch = db.batch();

--- a/lib/data/repositories/category_repository_impl.dart
+++ b/lib/data/repositories/category_repository_impl.dart
@@ -49,10 +49,6 @@ class CategoryRepositoryImpl implements CategoryRepository {
   @override
   Future<void> delete(String id) async {
     final db = await LocalDatabase.database;
-    await db.delete(
-      'categories',
-      where: 'id = ?',
-      whereArgs: [id],
-    );
+    await db.delete('categories', where: 'id = ?', whereArgs: [id]);
   }
 }

--- a/lib/data/repositories/transaction_repository_impl.dart
+++ b/lib/data/repositories/transaction_repository_impl.dart
@@ -8,10 +8,7 @@ class TransactionRepositoryImpl implements TransactionRepository {
   @override
   Future<List<Transaction>> getAll() async {
     final db = await LocalDatabase.database;
-    final maps = await db.query(
-      'transactions',
-      orderBy: 'date_time DESC',
-    );
+    final maps = await db.query('transactions', orderBy: 'date_time DESC');
     return maps.map(TransactionModel.fromMap).toList();
   }
 
@@ -28,18 +25,12 @@ class TransactionRepositoryImpl implements TransactionRepository {
   }
 
   @override
-  Future<List<Transaction>> getByDateRange(
-    DateTime start,
-    DateTime end,
-  ) async {
+  Future<List<Transaction>> getByDateRange(DateTime start, DateTime end) async {
     final db = await LocalDatabase.database;
     final maps = await db.query(
       'transactions',
       where: 'date_time >= ? AND date_time <= ?',
-      whereArgs: [
-        start.millisecondsSinceEpoch,
-        end.millisecondsSinceEpoch,
-      ],
+      whereArgs: [start.millisecondsSinceEpoch, end.millisecondsSinceEpoch],
       orderBy: 'date_time DESC',
     );
     return maps.map(TransactionModel.fromMap).toList();
@@ -82,10 +73,6 @@ class TransactionRepositoryImpl implements TransactionRepository {
   @override
   Future<void> delete(String id) async {
     final db = await LocalDatabase.database;
-    await db.delete(
-      'transactions',
-      where: 'id = ?',
-      whereArgs: [id],
-    );
+    await db.delete('transactions', where: 'id = ?', whereArgs: [id]);
   }
 }

--- a/lib/domain/entities/account.dart
+++ b/lib/domain/entities/account.dart
@@ -65,12 +65,12 @@ class Account extends Equatable {
 
   @override
   List<Object?> get props => [
-        id,
-        name,
-        type,
-        balance,
-        currency,
-        isArchived,
-        createdAt,
-      ];
+    id,
+    name,
+    type,
+    balance,
+    currency,
+    isArchived,
+    createdAt,
+  ];
 }

--- a/lib/domain/entities/category.dart
+++ b/lib/domain/entities/category.dart
@@ -22,12 +22,7 @@ class Category extends Equatable {
   });
 
   /// Returns a copy with the given fields replaced.
-  Category copyWith({
-    String? id,
-    String? name,
-    String? icon,
-    bool? isCustom,
-  }) {
+  Category copyWith({String? id, String? name, String? icon, bool? isCustom}) {
     return Category(
       id: id ?? this.id,
       name: name ?? this.name,

--- a/lib/domain/entities/transaction.dart
+++ b/lib/domain/entities/transaction.dart
@@ -70,14 +70,14 @@ class Transaction extends Equatable {
 
   @override
   List<Object?> get props => [
-        id,
-        amount,
-        type,
-        categoryId,
-        accountId,
-        toAccountId,
-        note,
-        isSettlement,
-        dateTime,
-      ];
+    id,
+    amount,
+    type,
+    categoryId,
+    accountId,
+    toAccountId,
+    note,
+    isSettlement,
+    dateTime,
+  ];
 }

--- a/lib/domain/usecases/log_transaction.dart
+++ b/lib/domain/usecases/log_transaction.dart
@@ -19,12 +19,11 @@ class LogTransaction {
   /// Throws [ArgumentError] if the referenced accounts don't exist.
   Future<Transaction> call(Transaction transaction) async {
     // Validate source account exists
-    final sourceAccount =
-        await _accountRepository.getById(transaction.accountId);
+    final sourceAccount = await _accountRepository.getById(
+      transaction.accountId,
+    );
     if (sourceAccount == null) {
-      throw ArgumentError(
-        'Source account not found: ${transaction.accountId}',
-      );
+      throw ArgumentError('Source account not found: ${transaction.accountId}');
     }
 
     switch (transaction.type) {
@@ -53,8 +52,9 @@ class LogTransaction {
         if (transaction.toAccountId == null) {
           throw ArgumentError('Transfer requires a destination account');
         }
-        final destAccount =
-            await _accountRepository.getById(transaction.toAccountId!);
+        final destAccount = await _accountRepository.getById(
+          transaction.toAccountId!,
+        );
         if (destAccount == null) {
           throw ArgumentError(
             'Destination account not found: ${transaction.toAccountId}',

--- a/lib/domain/usecases/manage_account.dart
+++ b/lib/domain/usecases/manage_account.dart
@@ -10,7 +10,7 @@ class ManageAccount {
   final Uuid _uuid;
 
   ManageAccount(this._accountRepository, {Uuid? uuid})
-      : _uuid = uuid ?? const Uuid();
+    : _uuid = uuid ?? const Uuid();
 
   /// Creates a new account after validation.
   ///

--- a/lib/domain/usecases/manage_account.dart
+++ b/lib/domain/usecases/manage_account.dart
@@ -1,0 +1,67 @@
+import 'package:uuid/uuid.dart';
+
+import '../entities/account.dart';
+import '../entities/enums.dart';
+import '../repositories/account_repository.dart';
+
+/// Encapsulates account CRUD operations with validation.
+class ManageAccount {
+  final AccountRepository _accountRepository;
+  final Uuid _uuid;
+
+  ManageAccount(this._accountRepository, {Uuid? uuid})
+      : _uuid = uuid ?? const Uuid();
+
+  /// Creates a new account after validation.
+  ///
+  /// - [name] must not be empty.
+  /// - [balance] must be ≥ 0.
+  /// - Generates a UUID and sets `createdAt` to now.
+  Future<Account> createAccount({
+    required String name,
+    required AccountType type,
+    required int balance,
+    String currency = 'IDR',
+  }) async {
+    final trimmedName = name.trim();
+    if (trimmedName.isEmpty) {
+      throw ArgumentError('Account name must not be empty');
+    }
+    if (balance < 0) {
+      throw ArgumentError('Initial balance must not be negative');
+    }
+
+    final account = Account(
+      id: _uuid.v4(),
+      name: trimmedName,
+      type: type,
+      balance: balance,
+      currency: currency,
+      createdAt: DateTime.now(),
+    );
+
+    return _accountRepository.insert(account);
+  }
+
+  /// Updates an existing account after validation.
+  ///
+  /// - [account.name] must not be empty.
+  Future<Account> updateAccount(Account account) async {
+    if (account.name.trim().isEmpty) {
+      throw ArgumentError('Account name must not be empty');
+    }
+
+    return _accountRepository.update(
+      account.copyWith(name: account.name.trim()),
+    );
+  }
+
+  /// Archives (soft-deletes) an account by [id].
+  Future<void> archiveAccount(String id) async {
+    final account = await _accountRepository.getById(id);
+    if (account == null) {
+      throw ArgumentError('Account not found: $id');
+    }
+    return _accountRepository.archive(id);
+  }
+}

--- a/lib/domain/usecases/settle_credit_bill.dart
+++ b/lib/domain/usecases/settle_credit_bill.dart
@@ -59,16 +59,10 @@ class SettleCreditBill {
     }
 
     // Deduct from asset
-    await _accountRepository.updateBalance(
-      source.id,
-      source.balance - amount,
-    );
+    await _accountRepository.updateBalance(source.id, source.balance - amount);
 
     // Reduce credit liability
-    await _accountRepository.updateBalance(
-      credit.id,
-      credit.balance - amount,
-    );
+    await _accountRepository.updateBalance(credit.id, credit.balance - amount);
 
     // Log as a settlement transfer
     final settlement = Transaction(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -68,11 +68,7 @@ class HomeShell extends StatefulWidget {
 class _HomeShellState extends State<HomeShell> {
   int _currentIndex = 0;
 
-  static const _screens = [
-    LedgerScreen(),
-    AccountsScreen(),
-    ReportsScreen(),
-  ];
+  static const _screens = [LedgerScreen(), AccountsScreen(), ReportsScreen()];
 
   static const _titles = ['Ledger', 'Accounts', 'Reports'];
 
@@ -82,9 +78,7 @@ class _HomeShellState extends State<HomeShell> {
       appBar: AppBar(
         title: Text(
           _titles[_currentIndex],
-          style: AppTypography.titleLarge.copyWith(
-            color: AppColors.inkBlue,
-          ),
+          style: AppTypography.titleLarge.copyWith(color: AppColors.inkBlue),
         ),
       ),
       body: _screens[_currentIndex],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -109,13 +109,15 @@ class _HomeShellState extends State<HomeShell> {
           ),
         ],
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          // TODO: Open Quick-Add bottom sheet
-        },
-        tooltip: 'Log Transaction',
-        child: const Icon(Icons.add),
-      ),
+      floatingActionButton: _currentIndex == 1
+          ? null // Accounts screen manages its own FAB
+          : FloatingActionButton(
+              onPressed: () {
+                // TODO: Open Quick-Add bottom sheet
+              },
+              tooltip: 'Log Transaction',
+              child: const Icon(Icons.add),
+            ),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'domain/repositories/account_repository.dart';
 import 'domain/repositories/transaction_repository.dart';
 import 'domain/usecases/calculate_net_position.dart';
 import 'domain/usecases/log_transaction.dart';
+import 'domain/usecases/manage_account.dart';
 import 'presentation/providers/account_provider.dart';
 import 'presentation/providers/transaction_provider.dart';
 import 'presentation/screens/accounts_screen.dart';
@@ -36,6 +37,7 @@ class VentExpenseApp extends StatelessWidget {
           create: (_) => AccountProvider(
             sl<AccountRepository>(),
             sl<CalculateNetPosition>(),
+            sl<ManageAccount>(),
           ),
         ),
         ChangeNotifierProvider(

--- a/lib/presentation/painters/paper_background.dart
+++ b/lib/presentation/painters/paper_background.dart
@@ -31,11 +31,7 @@ class PaperBackgroundPainter extends CustomPainter {
 
     const lineSpacing = 32.0;
     for (double y = lineSpacing; y < size.height; y += lineSpacing) {
-      canvas.drawLine(
-        Offset(24, y),
-        Offset(size.width - 24, y),
-        linePaint,
-      );
+      canvas.drawLine(Offset(24, y), Offset(size.width - 24, y), linePaint);
     }
 
     // — Left margin line (like a real ruled page) —
@@ -43,11 +39,7 @@ class PaperBackgroundPainter extends CustomPainter {
       ..color = AppColors.stampRed.withValues(alpha: 0.15)
       ..strokeWidth = 1.0;
 
-    canvas.drawLine(
-      const Offset(48, 0),
-      Offset(48, size.height),
-      marginPaint,
-    );
+    canvas.drawLine(const Offset(48, 0), Offset(48, size.height), marginPaint);
   }
 
   @override
@@ -62,9 +54,6 @@ class PaperBackground extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return CustomPaint(
-      painter: PaperBackgroundPainter(),
-      child: child,
-    );
+    return CustomPaint(painter: PaperBackgroundPainter(), child: child);
   }
 }

--- a/lib/presentation/providers/account_provider.dart
+++ b/lib/presentation/providers/account_provider.dart
@@ -1,15 +1,22 @@
 import 'package:flutter/foundation.dart';
 
 import '../../domain/entities/account.dart';
+import '../../domain/entities/enums.dart';
 import '../../domain/repositories/account_repository.dart';
 import '../../domain/usecases/calculate_net_position.dart';
+import '../../domain/usecases/manage_account.dart';
 
 /// Manages account state and net position calculation.
 class AccountProvider extends ChangeNotifier {
   final AccountRepository _accountRepository;
   final CalculateNetPosition _calculateNetPosition;
+  final ManageAccount _manageAccount;
 
-  AccountProvider(this._accountRepository, this._calculateNetPosition);
+  AccountProvider(
+    this._accountRepository,
+    this._calculateNetPosition,
+    this._manageAccount,
+  );
 
   List<Account> _accounts = [];
   NetPositionBreakdown? _breakdown;
@@ -26,6 +33,15 @@ class AccountProvider extends ChangeNotifier {
   NetPositionBreakdown? get breakdown => _breakdown;
   bool get isLoading => _isLoading;
   String? get error => _error;
+
+  /// Returns an account by [id] from the in-memory list, or `null`.
+  Account? getAccountById(String id) {
+    try {
+      return _accounts.firstWhere((a) => a.id == id);
+    } catch (_) {
+      return null;
+    }
+  }
 
   // — Actions —
 
@@ -46,10 +62,20 @@ class AccountProvider extends ChangeNotifier {
     }
   }
 
-  /// Adds a new account and refreshes the list.
-  Future<void> addAccount(Account account) async {
+  /// Creates a new account via the use case and refreshes the list.
+  Future<void> addAccount({
+    required String name,
+    required AccountType type,
+    required int balance,
+    String currency = 'IDR',
+  }) async {
     try {
-      await _accountRepository.insert(account);
+      await _manageAccount.createAccount(
+        name: name,
+        type: type,
+        balance: balance,
+        currency: currency,
+      );
       await loadAccounts();
     } catch (e) {
       _error = e.toString();
@@ -57,10 +83,10 @@ class AccountProvider extends ChangeNotifier {
     }
   }
 
-  /// Updates an account and refreshes the list.
+  /// Updates an account via the use case and refreshes the list.
   Future<void> updateAccount(Account account) async {
     try {
-      await _accountRepository.update(account);
+      await _manageAccount.updateAccount(account);
       await loadAccounts();
     } catch (e) {
       _error = e.toString();
@@ -68,11 +94,25 @@ class AccountProvider extends ChangeNotifier {
     }
   }
 
-  /// Archives an account and refreshes the list.
+  /// Archives an account via the use case and refreshes the list.
   Future<void> archiveAccount(String id) async {
     try {
-      await _accountRepository.archive(id);
+      await _manageAccount.archiveAccount(id);
       await loadAccounts();
+    } catch (e) {
+      _error = e.toString();
+      notifyListeners();
+    }
+  }
+
+  /// Restores an archived account and refreshes the list.
+  Future<void> unarchiveAccount(String id) async {
+    try {
+      final account = await _accountRepository.getById(id);
+      if (account != null) {
+        await _accountRepository.update(account.copyWith(isArchived: false));
+        await loadAccounts();
+      }
     } catch (e) {
       _error = e.toString();
       notifyListeners();

--- a/lib/presentation/providers/account_provider.dart
+++ b/lib/presentation/providers/account_provider.dart
@@ -26,8 +26,7 @@ class AccountProvider extends ChangeNotifier {
   // — Getters —
 
   List<Account> get accounts => _accounts;
-  List<Account> get assetAccounts =>
-      _accounts.where((a) => a.isAsset).toList();
+  List<Account> get assetAccounts => _accounts.where((a) => a.isAsset).toList();
   List<Account> get liabilityAccounts =>
       _accounts.where((a) => a.isLiability).toList();
   NetPositionBreakdown? get breakdown => _breakdown;

--- a/lib/presentation/screens/accounts_screen.dart
+++ b/lib/presentation/screens/accounts_screen.dart
@@ -38,9 +38,7 @@ class _AccountsScreenState extends State<AccountsScreen> {
             builder: (context, provider, _) {
               if (provider.isLoading && provider.accounts.isEmpty) {
                 return const Center(
-                  child: CircularProgressIndicator(
-                    color: AppColors.inkBlue,
-                  ),
+                  child: CircularProgressIndicator(color: AppColors.inkBlue),
                 );
               }
 
@@ -196,10 +194,7 @@ class _AccountsScreenState extends State<AccountsScreen> {
             ),
             child: Text(
               count.toString(),
-              style: AppTypography.label.copyWith(
-                color: color,
-                fontSize: 10,
-              ),
+              style: AppTypography.label.copyWith(color: color, fontSize: 10),
             ),
           ),
         ],
@@ -223,6 +218,7 @@ class _AccountsScreenState extends State<AccountsScreen> {
   // — Sheet & Dialog Helpers —
 
   Future<void> _showAddSheet(BuildContext context) async {
+    final provider = context.read<AccountProvider>();
     final result = await showModalBottomSheet<dynamic>(
       context: context,
       isScrollControlled: true,
@@ -234,16 +230,17 @@ class _AccountsScreenState extends State<AccountsScreen> {
     );
 
     if (result != null && result is Map<String, dynamic> && mounted) {
-      await context.read<AccountProvider>().addAccount(
-            name: result['name'] as String,
-            type: result['type'] as AccountType,
-            balance: result['balance'] as int,
-            currency: result['currency'] as String,
-          );
+      await provider.addAccount(
+        name: result['name'] as String,
+        type: result['type'] as AccountType,
+        balance: result['balance'] as int,
+        currency: result['currency'] as String,
+      );
     }
   }
 
   Future<void> _showEditSheet(BuildContext context, Account account) async {
+    final provider = context.read<AccountProvider>();
     final result = await showModalBottomSheet<dynamic>(
       context: context,
       isScrollControlled: true,
@@ -255,26 +252,20 @@ class _AccountsScreenState extends State<AccountsScreen> {
     );
 
     if (result != null && result is Account && mounted) {
-      await context.read<AccountProvider>().updateAccount(result);
+      await provider.updateAccount(result);
     }
   }
 
-  Future<void> _showArchiveDialog(
-    BuildContext context,
-    Account account,
-  ) async {
+  Future<void> _showArchiveDialog(BuildContext context, Account account) async {
+    final provider = context.read<AccountProvider>();
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
         backgroundColor: AppColors.paper,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-        ),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         title: Text(
           'Archive Account',
-          style: AppTypography.titleMedium.copyWith(
-            color: AppColors.inkDark,
-          ),
+          style: AppTypography.titleMedium.copyWith(color: AppColors.inkDark),
         ),
         content: Text(
           'Are you sure you want to archive "${account.name}"?\n\n'
@@ -306,7 +297,7 @@ class _AccountsScreenState extends State<AccountsScreen> {
     );
 
     if (confirmed == true && mounted) {
-      await context.read<AccountProvider>().archiveAccount(account.id);
+      await provider.archiveAccount(account.id);
     }
   }
 }

--- a/lib/presentation/screens/accounts_screen.dart
+++ b/lib/presentation/screens/accounts_screen.dart
@@ -1,44 +1,312 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 import '../../core/theme/app_colors.dart';
 import '../../core/theme/app_typography.dart';
+import '../../domain/entities/account.dart';
+import '../../domain/entities/enums.dart';
 import '../painters/paper_background.dart';
+import '../providers/account_provider.dart';
+import '../widgets/account_card.dart';
+import '../widgets/add_edit_account_sheet.dart';
+import '../widgets/net_position_card.dart';
 
 /// The accounts overview screen — lists asset and liability accounts.
-class AccountsScreen extends StatelessWidget {
+class AccountsScreen extends StatefulWidget {
   const AccountsScreen({super.key});
+
+  @override
+  State<AccountsScreen> createState() => _AccountsScreenState();
+}
+
+class _AccountsScreenState extends State<AccountsScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // Load accounts on first build
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<AccountProvider>().loadAccounts();
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return PaperBackground(
-      child: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(32),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const Icon(
-                Icons.account_balance_wallet_outlined,
-                size: 48,
-                color: AppColors.disabled,
-              ),
-              const SizedBox(height: 16),
-              Text(
-                'No accounts yet',
-                style: AppTypography.bodyLarge.copyWith(
-                  color: AppColors.inkLight,
-                ),
-              ),
-              const SizedBox(height: 8),
-              const Text(
-                'Add your first debit, cash, or credit account',
-                style: AppTypography.bodySmall,
-                textAlign: TextAlign.center,
-              ),
-            ],
+      child: Stack(
+        children: [
+          Consumer<AccountProvider>(
+            builder: (context, provider, _) {
+              if (provider.isLoading && provider.accounts.isEmpty) {
+                return const Center(
+                  child: CircularProgressIndicator(
+                    color: AppColors.inkBlue,
+                  ),
+                );
+              }
+
+              if (provider.accounts.isEmpty) {
+                return _buildEmptyState();
+              }
+
+              return _buildAccountsList(provider);
+            },
           ),
+
+          // — FAB —
+          Positioned(
+            right: 16,
+            bottom: 16,
+            child: FloatingActionButton(
+              heroTag: 'accounts_fab',
+              onPressed: () => _showAddSheet(context),
+              tooltip: 'Add Account',
+              child: const Icon(Icons.add),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              width: 80,
+              height: 80,
+              decoration: BoxDecoration(
+                color: AppColors.inkBlue.withValues(alpha: 0.06),
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: const Icon(
+                Icons.account_balance_wallet_outlined,
+                size: 40,
+                color: AppColors.inkBlue,
+              ),
+            ),
+            const SizedBox(height: 20),
+            Text(
+              'No accounts yet',
+              style: AppTypography.titleMedium.copyWith(
+                color: AppColors.inkDark,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Tap + to add your first debit, cash,\nor credit account',
+              style: AppTypography.bodySmall.copyWith(
+                color: AppColors.inkLight,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
         ),
       ),
     );
+  }
+
+  Widget _buildAccountsList(AccountProvider provider) {
+    final assets = provider.assetAccounts;
+    final liabilities = provider.liabilityAccounts;
+
+    return ListView(
+      padding: const EdgeInsets.only(bottom: 80),
+      children: [
+        // — Net Position Card —
+        NetPositionCard(breakdown: provider.breakdown),
+
+        const SizedBox(height: 12),
+
+        // — Assets Section —
+        _buildSectionHeader(
+          title: 'ASSETS',
+          count: assets.length,
+          color: AppColors.inkGreen,
+        ),
+
+        if (assets.isEmpty)
+          _buildSectionEmpty('No asset accounts')
+        else
+          ...assets.map(
+            (account) => AccountCard(
+              account: account,
+              onTap: () => _showEditSheet(context, account),
+              onLongPress: () => _showArchiveDialog(context, account),
+            ),
+          ),
+
+        const SizedBox(height: 16),
+
+        // — Liabilities Section —
+        _buildSectionHeader(
+          title: 'LIABILITIES',
+          count: liabilities.length,
+          color: AppColors.stampRed,
+        ),
+
+        if (liabilities.isEmpty)
+          _buildSectionEmpty('No liability accounts')
+        else
+          ...liabilities.map(
+            (account) => AccountCard(
+              account: account,
+              onTap: () => _showEditSheet(context, account),
+              onLongPress: () => _showArchiveDialog(context, account),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildSectionHeader({
+    required String title,
+    required int count,
+    required Color color,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 4),
+      child: Row(
+        children: [
+          Container(
+            width: 3,
+            height: 16,
+            decoration: BoxDecoration(
+              color: color,
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            title,
+            style: AppTypography.label.copyWith(
+              letterSpacing: 2.0,
+              color: color,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Text(
+              count.toString(),
+              style: AppTypography.label.copyWith(
+                color: color,
+                fontSize: 10,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSectionEmpty(String message) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+      child: Text(
+        message,
+        style: AppTypography.bodySmall.copyWith(
+          color: AppColors.disabled,
+          fontStyle: FontStyle.italic,
+        ),
+      ),
+    );
+  }
+
+  // — Sheet & Dialog Helpers —
+
+  Future<void> _showAddSheet(BuildContext context) async {
+    final result = await showModalBottomSheet<dynamic>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: AppColors.paper,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) => const AddEditAccountSheet(),
+    );
+
+    if (result != null && result is Map<String, dynamic> && mounted) {
+      await context.read<AccountProvider>().addAccount(
+            name: result['name'] as String,
+            type: result['type'] as AccountType,
+            balance: result['balance'] as int,
+            currency: result['currency'] as String,
+          );
+    }
+  }
+
+  Future<void> _showEditSheet(BuildContext context, Account account) async {
+    final result = await showModalBottomSheet<dynamic>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: AppColors.paper,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) => AddEditAccountSheet(existingAccount: account),
+    );
+
+    if (result != null && result is Account && mounted) {
+      await context.read<AccountProvider>().updateAccount(result);
+    }
+  }
+
+  Future<void> _showArchiveDialog(
+    BuildContext context,
+    Account account,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: AppColors.paper,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+        ),
+        title: Text(
+          'Archive Account',
+          style: AppTypography.titleMedium.copyWith(
+            color: AppColors.inkDark,
+          ),
+        ),
+        content: Text(
+          'Are you sure you want to archive "${account.name}"?\n\n'
+          'The account will be hidden but its transaction history is preserved.',
+          style: AppTypography.bodyMedium,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(
+              'Cancel',
+              style: AppTypography.bodyMedium.copyWith(
+                color: AppColors.inkLight,
+              ),
+            ),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: Text(
+              'Archive',
+              style: AppTypography.bodyMedium.copyWith(
+                color: AppColors.stampRed,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true && mounted) {
+      await context.read<AccountProvider>().archiveAccount(account.id);
+    }
   }
 }

--- a/lib/presentation/screens/ledger_screen.dart
+++ b/lib/presentation/screens/ledger_screen.dart
@@ -24,9 +24,7 @@ class LedgerScreen extends StatelessWidget {
                     children: [
                       Text(
                         'NET POSITION',
-                        style: AppTypography.label.copyWith(
-                          letterSpacing: 2.0,
-                        ),
+                        style: AppTypography.label.copyWith(letterSpacing: 2.0),
                       ),
                       const SizedBox(height: 8),
                       Text(
@@ -114,15 +112,9 @@ class LedgerScreen extends StatelessWidget {
   Widget _buildSummaryItem(String label, String amount, Color color) {
     return Column(
       children: [
-        Text(
-          label.toUpperCase(),
-          style: AppTypography.label,
-        ),
+        Text(label.toUpperCase(), style: AppTypography.label),
         const SizedBox(height: 4),
-        Text(
-          amount,
-          style: AppTypography.amountMedium.copyWith(color: color),
-        ),
+        Text(amount, style: AppTypography.amountMedium.copyWith(color: color)),
       ],
     );
   }

--- a/lib/presentation/widgets/account_card.dart
+++ b/lib/presentation/widgets/account_card.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+
+import '../../core/theme/app_colors.dart';
+import '../../core/theme/app_typography.dart';
+import '../../domain/entities/account.dart';
+import '../../domain/entities/enums.dart';
+import '../../domain/value_objects/money.dart';
+
+/// A card displaying a single account with name, type badge, and balance.
+///
+/// - Tap to edit
+/// - Long press to archive
+class AccountCard extends StatelessWidget {
+  final Account account;
+  final VoidCallback? onTap;
+  final VoidCallback? onLongPress;
+
+  const AccountCard({
+    super.key,
+    required this.account,
+    this.onTap,
+    this.onLongPress,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isAsset = account.isAsset;
+    final accentColor = isAsset ? AppColors.inkGreen : AppColors.stampRed;
+    final balance = Money(cents: account.balance, currency: account.currency);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          onLongPress: onLongPress,
+          borderRadius: BorderRadius.circular(10),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+            decoration: BoxDecoration(
+              color: AppColors.paper,
+              borderRadius: BorderRadius.circular(10),
+              border: Border.all(
+                color: AppColors.divider,
+                width: 0.5,
+              ),
+            ),
+            child: Row(
+              children: [
+                // — Account icon —
+                Container(
+                  width: 40,
+                  height: 40,
+                  decoration: BoxDecoration(
+                    color: accentColor.withValues(alpha: 0.08),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Icon(
+                    _iconForType(account.type),
+                    color: accentColor,
+                    size: 20,
+                  ),
+                ),
+                const SizedBox(width: 12),
+
+                // — Name & type badge —
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        account.name,
+                        style: AppTypography.titleMedium,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      const SizedBox(height: 2),
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 2,
+                        ),
+                        decoration: BoxDecoration(
+                          color: accentColor.withValues(alpha: 0.08),
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        child: Text(
+                          _labelForType(account.type),
+                          style: AppTypography.label.copyWith(
+                            color: accentColor,
+                            fontSize: 10,
+                            letterSpacing: 1.0,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+
+                // — Balance —
+                Text(
+                  balance.formatted,
+                  style: AppTypography.amountMedium.copyWith(
+                    color: accentColor,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  IconData _iconForType(AccountType type) {
+    switch (type) {
+      case AccountType.debit:
+        return Icons.account_balance_outlined;
+      case AccountType.cash:
+        return Icons.payments_outlined;
+      case AccountType.credit:
+        return Icons.credit_card_outlined;
+    }
+  }
+
+  String _labelForType(AccountType type) {
+    switch (type) {
+      case AccountType.debit:
+        return 'DEBIT';
+      case AccountType.cash:
+        return 'CASH';
+      case AccountType.credit:
+        return 'CREDIT';
+    }
+  }
+}

--- a/lib/presentation/widgets/account_card.dart
+++ b/lib/presentation/widgets/account_card.dart
@@ -41,10 +41,7 @@ class AccountCard extends StatelessWidget {
             decoration: BoxDecoration(
               color: AppColors.paper,
               borderRadius: BorderRadius.circular(10),
-              border: Border.all(
-                color: AppColors.divider,
-                width: 0.5,
-              ),
+              border: Border.all(color: AppColors.divider, width: 0.5),
             ),
             child: Row(
               children: [

--- a/lib/presentation/widgets/add_edit_account_sheet.dart
+++ b/lib/presentation/widgets/add_edit_account_sheet.dart
@@ -150,9 +150,7 @@ class _AddEditAccountSheetState extends State<AddEditAccountSheet> {
                             Text(
                               _labelForType(type),
                               style: AppTypography.label.copyWith(
-                                color: isSelected
-                                    ? color
-                                    : AppColors.disabled,
+                                color: isSelected ? color : AppColors.disabled,
                                 fontSize: 10,
                               ),
                             ),
@@ -174,9 +172,7 @@ class _AddEditAccountSheetState extends State<AddEditAccountSheet> {
                   width: 80,
                   child: TextFormField(
                     controller: _currencyController,
-                    decoration: const InputDecoration(
-                      labelText: 'Currency',
-                    ),
+                    decoration: const InputDecoration(labelText: 'Currency'),
                     textAlign: TextAlign.center,
                     textCapitalization: TextCapitalization.characters,
                     enabled: !_isEditing,
@@ -192,9 +188,7 @@ class _AddEditAccountSheetState extends State<AddEditAccountSheet> {
                       hintText: '0',
                     ),
                     keyboardType: TextInputType.number,
-                    inputFormatters: [
-                      FilteringTextInputFormatter.digitsOnly,
-                    ],
+                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                     style: AppTypography.amountMedium,
                     validator: (value) {
                       if (value == null || value.trim().isEmpty) {
@@ -230,9 +224,7 @@ class _AddEditAccountSheetState extends State<AddEditAccountSheet> {
                     color: AppColors.paper,
                   ),
                 ),
-                child: Text(
-                  _isEditing ? 'Save Changes' : 'Create Account',
-                ),
+                child: Text(_isEditing ? 'Save Changes' : 'Create Account'),
               ),
             ),
           ],

--- a/lib/presentation/widgets/add_edit_account_sheet.dart
+++ b/lib/presentation/widgets/add_edit_account_sheet.dart
@@ -1,0 +1,289 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../core/theme/app_colors.dart';
+import '../../core/theme/app_typography.dart';
+import '../../domain/entities/account.dart';
+import '../../domain/entities/enums.dart';
+
+/// Bottom sheet for creating or editing an account.
+///
+/// In edit mode, fields are pre-filled with the existing account data.
+class AddEditAccountSheet extends StatefulWidget {
+  /// If provided, the sheet operates in edit mode.
+  final Account? existingAccount;
+
+  const AddEditAccountSheet({super.key, this.existingAccount});
+
+  @override
+  State<AddEditAccountSheet> createState() => _AddEditAccountSheetState();
+}
+
+class _AddEditAccountSheetState extends State<AddEditAccountSheet> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _nameController;
+  late final TextEditingController _balanceController;
+  late final TextEditingController _currencyController;
+  late AccountType _selectedType;
+
+  bool get _isEditing => widget.existingAccount != null;
+
+  @override
+  void initState() {
+    super.initState();
+    final account = widget.existingAccount;
+    _nameController = TextEditingController(text: account?.name ?? '');
+    _balanceController = TextEditingController(
+      text: account != null ? account.balance.toString() : '',
+    );
+    _currencyController = TextEditingController(
+      text: account?.currency ?? 'IDR',
+    );
+    _selectedType = account?.type ?? AccountType.debit;
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _balanceController.dispose();
+    _currencyController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 24,
+        right: 24,
+        top: 16,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 24,
+      ),
+      child: Form(
+        key: _formKey,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // — Handle bar —
+            Center(
+              child: Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: AppColors.divider,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // — Title —
+            Text(
+              _isEditing ? 'Edit Account' : 'New Account',
+              style: AppTypography.titleLarge.copyWith(
+                color: AppColors.inkBlue,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+
+            // — Name field —
+            TextFormField(
+              controller: _nameController,
+              decoration: const InputDecoration(
+                labelText: 'Account Name',
+                hintText: 'e.g. BCA Debit, Cash Wallet',
+              ),
+              textCapitalization: TextCapitalization.words,
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return 'Please enter an account name';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 16),
+
+            // — Type selector —
+            Text(
+              'ACCOUNT TYPE',
+              style: AppTypography.label.copyWith(letterSpacing: 1.5),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: AccountType.values.map((type) {
+                final isSelected = _selectedType == type;
+                final color = (type == AccountType.credit)
+                    ? AppColors.stampRed
+                    : AppColors.inkGreen;
+                return Expanded(
+                  child: Padding(
+                    padding: EdgeInsets.only(
+                      right: type != AccountType.credit ? 8 : 0,
+                    ),
+                    child: GestureDetector(
+                      onTap: _isEditing
+                          ? null
+                          : () => setState(() => _selectedType = type),
+                      child: AnimatedContainer(
+                        duration: const Duration(milliseconds: 200),
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                        decoration: BoxDecoration(
+                          color: isSelected
+                              ? color.withValues(alpha: 0.1)
+                              : AppColors.paper,
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(
+                            color: isSelected ? color : AppColors.divider,
+                            width: isSelected ? 1.5 : 0.5,
+                          ),
+                        ),
+                        child: Column(
+                          children: [
+                            Icon(
+                              _iconForType(type),
+                              size: 20,
+                              color: isSelected ? color : AppColors.disabled,
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              _labelForType(type),
+                              style: AppTypography.label.copyWith(
+                                color: isSelected
+                                    ? color
+                                    : AppColors.disabled,
+                                fontSize: 10,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                );
+              }).toList(),
+            ),
+            const SizedBox(height: 16),
+
+            // — Balance field —
+            Row(
+              children: [
+                // Currency
+                SizedBox(
+                  width: 80,
+                  child: TextFormField(
+                    controller: _currencyController,
+                    decoration: const InputDecoration(
+                      labelText: 'Currency',
+                    ),
+                    textAlign: TextAlign.center,
+                    textCapitalization: TextCapitalization.characters,
+                    enabled: !_isEditing,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                // Amount
+                Expanded(
+                  child: TextFormField(
+                    controller: _balanceController,
+                    decoration: InputDecoration(
+                      labelText: _isEditing ? 'Balance' : 'Initial Balance',
+                      hintText: '0',
+                    ),
+                    keyboardType: TextInputType.number,
+                    inputFormatters: [
+                      FilteringTextInputFormatter.digitsOnly,
+                    ],
+                    style: AppTypography.amountMedium,
+                    validator: (value) {
+                      if (value == null || value.trim().isEmpty) {
+                        return 'Enter a balance';
+                      }
+                      final parsed = int.tryParse(value);
+                      if (parsed == null) {
+                        return 'Invalid number';
+                      }
+                      if (!_isEditing && parsed < 0) {
+                        return 'Balance cannot be negative';
+                      }
+                      return null;
+                    },
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 24),
+
+            // — Submit button —
+            SizedBox(
+              height: 48,
+              child: ElevatedButton(
+                onPressed: _submit,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.inkBlue,
+                  foregroundColor: AppColors.paper,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  textStyle: AppTypography.titleMedium.copyWith(
+                    color: AppColors.paper,
+                  ),
+                ),
+                child: Text(
+                  _isEditing ? 'Save Changes' : 'Create Account',
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _submit() {
+    if (!_formKey.currentState!.validate()) return;
+
+    final name = _nameController.text.trim();
+    final balance = int.parse(_balanceController.text.trim());
+    final currency = _currencyController.text.trim().toUpperCase();
+
+    if (_isEditing) {
+      final updated = widget.existingAccount!.copyWith(
+        name: name,
+        balance: balance,
+      );
+      Navigator.of(context).pop(updated);
+    } else {
+      // Return a map with the create params
+      Navigator.of(context).pop({
+        'name': name,
+        'type': _selectedType,
+        'balance': balance,
+        'currency': currency,
+      });
+    }
+  }
+
+  IconData _iconForType(AccountType type) {
+    switch (type) {
+      case AccountType.debit:
+        return Icons.account_balance_outlined;
+      case AccountType.cash:
+        return Icons.payments_outlined;
+      case AccountType.credit:
+        return Icons.credit_card_outlined;
+    }
+  }
+
+  String _labelForType(AccountType type) {
+    switch (type) {
+      case AccountType.debit:
+        return 'DEBIT';
+      case AccountType.cash:
+        return 'CASH';
+      case AccountType.credit:
+        return 'CREDIT';
+    }
+  }
+}

--- a/lib/presentation/widgets/net_position_card.dart
+++ b/lib/presentation/widgets/net_position_card.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+
+import '../../core/theme/app_colors.dart';
+import '../../core/theme/app_typography.dart';
+import '../../domain/usecases/calculate_net_position.dart';
+import '../../domain/value_objects/money.dart';
+
+/// Displays the Net Position breakdown: Total Assets, Total Liabilities, Net.
+class NetPositionCard extends StatelessWidget {
+  final NetPositionBreakdown? breakdown;
+
+  const NetPositionCard({super.key, required this.breakdown});
+
+  @override
+  Widget build(BuildContext context) {
+    final assets = breakdown?.totalAssets ?? const Money(cents: 0);
+    final liabilities = breakdown?.totalLiabilities ?? const Money(cents: 0);
+    final net = breakdown?.netPosition ?? const Money(cents: 0);
+
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: AppColors.paperElevated,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.divider, width: 0.5),
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.inkDark.withValues(alpha: 0.04),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // — Header —
+          Text(
+            'NET POSITION',
+            style: AppTypography.label.copyWith(
+              letterSpacing: 2.0,
+              color: AppColors.inkLight,
+            ),
+          ),
+          const SizedBox(height: 8),
+
+          // — Net Position amount —
+          Text(
+            net.formatted,
+            style: AppTypography.amountLarge.copyWith(
+              color: net.isNegative ? AppColors.stampRed : AppColors.inkGreen,
+              fontSize: 32,
+            ),
+          ),
+          const SizedBox(height: 16),
+
+          // — Dotted divider —
+          _buildDottedDivider(),
+          const SizedBox(height: 12),
+
+          // — Assets row —
+          _buildBreakdownRow(
+            label: 'Total Assets',
+            amount: assets,
+            color: AppColors.inkGreen,
+            icon: Icons.arrow_upward_rounded,
+          ),
+          const SizedBox(height: 8),
+
+          // — Liabilities row —
+          _buildBreakdownRow(
+            label: 'Total Liabilities',
+            amount: liabilities,
+            color: AppColors.stampRed,
+            icon: Icons.arrow_downward_rounded,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBreakdownRow({
+    required String label,
+    required Money amount,
+    required Color color,
+    required IconData icon,
+  }) {
+    return Row(
+      children: [
+        Container(
+          width: 28,
+          height: 28,
+          decoration: BoxDecoration(
+            color: color.withValues(alpha: 0.1),
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Icon(icon, size: 16, color: color),
+        ),
+        const SizedBox(width: 10),
+        Text(label, style: AppTypography.bodyMedium),
+        const Spacer(),
+        Text(
+          amount.formatted,
+          style: AppTypography.amountSmall.copyWith(color: color),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDottedDivider() {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final dashWidth = 4.0;
+        final dashSpace = 3.0;
+        final dashCount =
+            (constraints.maxWidth / (dashWidth + dashSpace)).floor();
+        return Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: List.generate(dashCount, (_) {
+            return SizedBox(
+              width: dashWidth,
+              height: 1,
+              child: DecoratedBox(
+                decoration: BoxDecoration(color: AppColors.divider),
+              ),
+            );
+          }),
+        );
+      },
+    );
+  }
+}

--- a/lib/presentation/widgets/net_position_card.dart
+++ b/lib/presentation/widgets/net_position_card.dart
@@ -111,14 +111,14 @@ class NetPositionCard extends StatelessWidget {
   Widget _buildDottedDivider() {
     return LayoutBuilder(
       builder: (context, constraints) {
-        final dashWidth = 4.0;
-        final dashSpace = 3.0;
-        final dashCount =
-            (constraints.maxWidth / (dashWidth + dashSpace)).floor();
+        const dashWidth = 4.0;
+        const dashSpace = 3.0;
+        final dashCount = (constraints.maxWidth / (dashWidth + dashSpace))
+            .floor();
         return Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: List.generate(dashCount, (_) {
-            return SizedBox(
+            return const SizedBox(
               width: dashWidth,
               height: 1,
               child: DecoratedBox(

--- a/test/domain/usecases/calculate_net_position_test.dart
+++ b/test/domain/usecases/calculate_net_position_test.dart
@@ -1,0 +1,240 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vent_expense_pro/domain/entities/account.dart';
+import 'package:vent_expense_pro/domain/entities/enums.dart';
+import 'package:vent_expense_pro/domain/repositories/account_repository.dart';
+import 'package:vent_expense_pro/domain/usecases/calculate_net_position.dart';
+
+/// A simple in-memory fake of [AccountRepository] for testing.
+class FakeAccountRepository implements AccountRepository {
+  final List<Account> _accounts = [];
+
+  void seed(List<Account> accounts) {
+    _accounts
+      ..clear()
+      ..addAll(accounts);
+  }
+
+  @override
+  Future<List<Account>> getAll() async =>
+      _accounts.where((a) => !a.isArchived).toList();
+
+  @override
+  Future<List<Account>> getByType(AccountType type) async =>
+      _accounts.where((a) => a.type == type && !a.isArchived).toList();
+
+  @override
+  Future<Account?> getById(String id) async {
+    try {
+      return _accounts.firstWhere((a) => a.id == id);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  Future<Account> insert(Account account) async {
+    _accounts.add(account);
+    return account;
+  }
+
+  @override
+  Future<Account> update(Account account) async {
+    final index = _accounts.indexWhere((a) => a.id == account.id);
+    if (index != -1) _accounts[index] = account;
+    return account;
+  }
+
+  @override
+  Future<void> archive(String id) async {
+    final index = _accounts.indexWhere((a) => a.id == id);
+    if (index != -1) {
+      _accounts[index] = _accounts[index].copyWith(isArchived: true);
+    }
+  }
+
+  @override
+  Future<void> updateBalance(String id, int newBalance) async {
+    final index = _accounts.indexWhere((a) => a.id == id);
+    if (index != -1) {
+      _accounts[index] = _accounts[index].copyWith(balance: newBalance);
+    }
+  }
+}
+
+void main() {
+  late FakeAccountRepository fakeRepo;
+  late CalculateNetPosition calculateNetPosition;
+  final now = DateTime(2026, 2, 21);
+
+  setUp(() {
+    fakeRepo = FakeAccountRepository();
+    calculateNetPosition = CalculateNetPosition(fakeRepo);
+  });
+
+  group('CalculateNetPosition.call', () {
+    test('should return zero for no accounts', () async {
+      final result = await calculateNetPosition();
+      expect(result.cents, 0);
+    });
+
+    test('should sum only asset accounts', () async {
+      fakeRepo.seed([
+        Account(
+          id: '1',
+          name: 'Debit',
+          type: AccountType.debit,
+          balance: 300000,
+          createdAt: now,
+        ),
+        Account(
+          id: '2',
+          name: 'Cash',
+          type: AccountType.cash,
+          balance: 200000,
+          createdAt: now,
+        ),
+      ]);
+
+      final result = await calculateNetPosition();
+      expect(result.cents, 500000);
+    });
+
+    test('should subtract liabilities from assets', () async {
+      fakeRepo.seed([
+        Account(
+          id: '1',
+          name: 'BCA Debit',
+          type: AccountType.debit,
+          balance: 500000,
+          createdAt: now,
+        ),
+        Account(
+          id: '2',
+          name: 'Visa Card',
+          type: AccountType.credit,
+          balance: 150000,
+          createdAt: now,
+        ),
+      ]);
+
+      final result = await calculateNetPosition();
+      expect(result.cents, 350000); // 500K - 150K
+    });
+
+    test('should return negative when liabilities exceed assets', () async {
+      fakeRepo.seed([
+        Account(
+          id: '1',
+          name: 'Cash',
+          type: AccountType.cash,
+          balance: 50000,
+          createdAt: now,
+        ),
+        Account(
+          id: '2',
+          name: 'Credit Card',
+          type: AccountType.credit,
+          balance: 200000,
+          createdAt: now,
+        ),
+      ]);
+
+      final result = await calculateNetPosition();
+      expect(result.cents, -150000);
+      expect(result.isNegative, true);
+    });
+  });
+
+  group('CalculateNetPosition.breakdown', () {
+    test('should return correct breakdown with mixed accounts', () async {
+      fakeRepo.seed([
+        Account(
+          id: '1',
+          name: 'BCA Debit',
+          type: AccountType.debit,
+          balance: 500000,
+          createdAt: now,
+        ),
+        Account(
+          id: '2',
+          name: 'Cash',
+          type: AccountType.cash,
+          balance: 200000,
+          createdAt: now,
+        ),
+        Account(
+          id: '3',
+          name: 'Visa Card',
+          type: AccountType.credit,
+          balance: 150000,
+          createdAt: now,
+        ),
+      ]);
+
+      final breakdown = await calculateNetPosition.breakdown();
+
+      expect(breakdown.totalAssets.cents, 700000);
+      expect(breakdown.totalLiabilities.cents, 150000);
+      expect(breakdown.netPosition.cents, 550000);
+    });
+
+    test('should return zero breakdown for empty accounts', () async {
+      final breakdown = await calculateNetPosition.breakdown();
+
+      expect(breakdown.totalAssets.cents, 0);
+      expect(breakdown.totalLiabilities.cents, 0);
+      expect(breakdown.netPosition.cents, 0);
+    });
+
+    test('should exclude archived accounts', () async {
+      fakeRepo.seed([
+        Account(
+          id: '1',
+          name: 'Active',
+          type: AccountType.debit,
+          balance: 500000,
+          createdAt: now,
+        ),
+        Account(
+          id: '2',
+          name: 'Archived',
+          type: AccountType.debit,
+          balance: 300000,
+          isArchived: true,
+          createdAt: now,
+        ),
+      ]);
+
+      final breakdown = await calculateNetPosition.breakdown();
+
+      // Only the active account should be counted
+      expect(breakdown.totalAssets.cents, 500000);
+      expect(breakdown.netPosition.cents, 500000);
+    });
+
+    test('should handle only liability accounts', () async {
+      fakeRepo.seed([
+        Account(
+          id: '1',
+          name: 'Card A',
+          type: AccountType.credit,
+          balance: 100000,
+          createdAt: now,
+        ),
+        Account(
+          id: '2',
+          name: 'Card B',
+          type: AccountType.credit,
+          balance: 200000,
+          createdAt: now,
+        ),
+      ]);
+
+      final breakdown = await calculateNetPosition.breakdown();
+
+      expect(breakdown.totalAssets.cents, 0);
+      expect(breakdown.totalLiabilities.cents, 300000);
+      expect(breakdown.netPosition.cents, -300000);
+    });
+  });
+}

--- a/test/domain/usecases/manage_account_test.dart
+++ b/test/domain/usecases/manage_account_test.dart
@@ -1,0 +1,247 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vent_expense_pro/domain/entities/account.dart';
+import 'package:vent_expense_pro/domain/entities/enums.dart';
+import 'package:vent_expense_pro/domain/repositories/account_repository.dart';
+import 'package:vent_expense_pro/domain/usecases/manage_account.dart';
+
+/// A simple in-memory fake of [AccountRepository] for testing.
+class FakeAccountRepository implements AccountRepository {
+  final List<Account> _accounts = [];
+
+  @override
+  Future<List<Account>> getAll() async =>
+      _accounts.where((a) => !a.isArchived).toList();
+
+  @override
+  Future<List<Account>> getByType(AccountType type) async =>
+      _accounts.where((a) => a.type == type && !a.isArchived).toList();
+
+  @override
+  Future<Account?> getById(String id) async {
+    try {
+      return _accounts.firstWhere((a) => a.id == id);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  Future<Account> insert(Account account) async {
+    _accounts.add(account);
+    return account;
+  }
+
+  @override
+  Future<Account> update(Account account) async {
+    final index = _accounts.indexWhere((a) => a.id == account.id);
+    if (index != -1) {
+      _accounts[index] = account;
+    }
+    return account;
+  }
+
+  @override
+  Future<void> archive(String id) async {
+    final index = _accounts.indexWhere((a) => a.id == id);
+    if (index != -1) {
+      _accounts[index] = _accounts[index].copyWith(isArchived: true);
+    }
+  }
+
+  @override
+  Future<void> updateBalance(String id, int newBalance) async {
+    final index = _accounts.indexWhere((a) => a.id == id);
+    if (index != -1) {
+      _accounts[index] = _accounts[index].copyWith(balance: newBalance);
+    }
+  }
+}
+
+void main() {
+  late FakeAccountRepository fakeRepo;
+  late ManageAccount manageAccount;
+
+  setUp(() {
+    fakeRepo = FakeAccountRepository();
+    manageAccount = ManageAccount(fakeRepo);
+  });
+
+  group('ManageAccount.createAccount', () {
+    test('should create an account with valid inputs', () async {
+      final account = await manageAccount.createAccount(
+        name: 'BCA Debit',
+        type: AccountType.debit,
+        balance: 500000,
+      );
+
+      expect(account.name, 'BCA Debit');
+      expect(account.type, AccountType.debit);
+      expect(account.balance, 500000);
+      expect(account.currency, 'IDR');
+      expect(account.isArchived, false);
+      expect(account.id, isNotEmpty);
+    });
+
+    test('should trim whitespace from name', () async {
+      final account = await manageAccount.createAccount(
+        name: '  Cash Wallet  ',
+        type: AccountType.cash,
+        balance: 100000,
+      );
+
+      expect(account.name, 'Cash Wallet');
+    });
+
+    test('should throw when name is empty', () async {
+      expect(
+        () => manageAccount.createAccount(
+          name: '',
+          type: AccountType.debit,
+          balance: 0,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('should throw when name is only whitespace', () async {
+      expect(
+        () => manageAccount.createAccount(
+          name: '   ',
+          type: AccountType.debit,
+          balance: 0,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('should throw when balance is negative', () async {
+      expect(
+        () => manageAccount.createAccount(
+          name: 'Test',
+          type: AccountType.debit,
+          balance: -100,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('should accept zero balance', () async {
+      final account = await manageAccount.createAccount(
+        name: 'Empty Account',
+        type: AccountType.cash,
+        balance: 0,
+      );
+
+      expect(account.balance, 0);
+    });
+
+    test('should accept custom currency', () async {
+      final account = await manageAccount.createAccount(
+        name: 'USD Account',
+        type: AccountType.debit,
+        balance: 1000,
+        currency: 'USD',
+      );
+
+      expect(account.currency, 'USD');
+    });
+
+    test('should generate unique IDs', () async {
+      final a = await manageAccount.createAccount(
+        name: 'Account A',
+        type: AccountType.debit,
+        balance: 100,
+      );
+      final b = await manageAccount.createAccount(
+        name: 'Account B',
+        type: AccountType.cash,
+        balance: 200,
+      );
+
+      expect(a.id, isNot(equals(b.id)));
+    });
+
+    test('should persist to repository', () async {
+      await manageAccount.createAccount(
+        name: 'Persisted',
+        type: AccountType.debit,
+        balance: 300,
+      );
+
+      final allAccounts = await fakeRepo.getAll();
+      expect(allAccounts, hasLength(1));
+      expect(allAccounts.first.name, 'Persisted');
+    });
+  });
+
+  group('ManageAccount.updateAccount', () {
+    test('should update account name', () async {
+      final original = await manageAccount.createAccount(
+        name: 'Old Name',
+        type: AccountType.debit,
+        balance: 100,
+      );
+
+      final updated = await manageAccount.updateAccount(
+        original.copyWith(name: 'New Name'),
+      );
+
+      expect(updated.name, 'New Name');
+    });
+
+    test('should throw when updated name is empty', () async {
+      final original = await manageAccount.createAccount(
+        name: 'Valid',
+        type: AccountType.debit,
+        balance: 100,
+      );
+
+      expect(
+        () => manageAccount.updateAccount(original.copyWith(name: '')),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('should trim updated name', () async {
+      final original = await manageAccount.createAccount(
+        name: 'Original',
+        type: AccountType.debit,
+        balance: 100,
+      );
+
+      final updated = await manageAccount.updateAccount(
+        original.copyWith(name: '  Trimmed  '),
+      );
+
+      expect(updated.name, 'Trimmed');
+    });
+  });
+
+  group('ManageAccount.archiveAccount', () {
+    test('should archive an existing account', () async {
+      final account = await manageAccount.createAccount(
+        name: 'To Archive',
+        type: AccountType.cash,
+        balance: 100,
+      );
+
+      await manageAccount.archiveAccount(account.id);
+
+      // Archived accounts don't appear in getAll()
+      final all = await fakeRepo.getAll();
+      expect(all, isEmpty);
+
+      // But can still be found by ID
+      final found = await fakeRepo.getById(account.id);
+      expect(found, isNotNull);
+      expect(found!.isArchived, true);
+    });
+
+    test('should throw when account not found', () async {
+      expect(
+        () => manageAccount.archiveAccount('nonexistent-id'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Pull Request: feat: Implement 5.1 Accounts Management

**Target Branch:** `1.0.0`
**Source Branch:** `account-management-1.0.0`

---

## Title
`feat: Implement 5.1 Accounts Management`

---

## Description

This PR implements the **5.1 Accounts Management** feature as specified in the PRD (Requirements ACC-01 through ACC-05). It provides a full accounts overview with net position tracking, asset/liability grouping, and seamless account creation/editing.

### Key Changes

#### 💎 Domain Layer
- Created [ManageAccount](file:///Users/syubbanfakhriya/Desktop/Repository/side-project/VentExpensePro/lib/domain/usecases/manage_account.dart#8-68) use case handle validation logic (name trimming, balance checks, UUID generation).
- Updated [Account](file:///Users/syubbanfakhriya/Desktop/Repository/side-project/VentExpensePro/lib/domain/entities/account.dart#6-77) and `AccountType` enums.

#### 🔧 Data Layer
- Wired [AccountRepositoryImpl](file:///Users/syubbanfakhriya/Desktop/Repository/side-project/VentExpensePro/lib/data/repositories/account_repository_impl.dart#8-89) with the new use case requirements.

#### 🎨 Presentation Layer
- **New Widgets**:
  - [NetPositionCard](file:///Users/syubbanfakhriya/Desktop/Repository/side-project/VentExpensePro/lib/presentation/widgets/net_position_card.dart#9-134): Visual breakdown of Assets, Liabilities, and Net Position.
  - [AccountCard](file:///Users/syubbanfakhriya/Desktop/Repository/side-project/VentExpensePro/lib/presentation/widgets/account_card.dart#13-137): Stationery-styled rows with type-specific badges.
  - [AddEditAccountSheet](file:///Users/syubbanfakhriya/Desktop/Repository/side-project/VentExpensePro/lib/presentation/widgets/add_edit_account_sheet.dart#12-21): Reactive bottom sheet for account management.
- **AccountsScreen**: Full implementation replacing the placeholder, including auto-loading, section headers (Assets/Liabilities), and FAB management.
- **Provider**: Enhanced [AccountProvider](file:///Users/syubbanfakhriya/Desktop/Repository/side-project/VentExpensePro/lib/presentation/providers/account_provider.dart#10-122) with [ManageAccount](file:///Users/syubbanfakhriya/Desktop/Repository/side-project/VentExpensePro/lib/domain/usecases/manage_account.dart#8-68) integration and helper methods.

#### 🐛 Bug Fixes
- Fixed an issue in [HomeShell](file:///Users/syubbanfakhriya/Desktop/Repository/side-project/VentExpensePro/lib/main.dart#61-67) where the global FAB overlapped the [AccountsScreen](file:///Users/syubbanfakhriya/Desktop/Repository/side-project/VentExpensePro/lib/presentation/screens/accounts_screen.dart#15-21) FAB. The global FAB is now hidden when on the Accounts tab.

### 🧪 Verification Results

- **Unit Tests**: 22 new tests added (14 for [ManageAccount](file:///Users/syubbanfakhriya/Desktop/Repository/side-project/VentExpensePro/lib/domain/usecases/manage_account.dart#8-68), 8 for [CalculateNetPosition](file:///Users/syubbanfakhriya/Desktop/Repository/side-project/VentExpensePro/lib/domain/usecases/calculate_net_position.dart#7-55)).
- **Total Tests**: **42 passing** (`flutter test`).
- **Manual Check**: Verified creation, editing, and archiving flows on Android emulator.

---
*Created with love by Antigravity*
