### PR TITLE
Merge smart settlement into 1.0.0

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'domain/usecases/manage_transaction.dart';
 import 'presentation/providers/account_provider.dart';
 import 'presentation/providers/category_provider.dart';
 import 'presentation/providers/transaction_provider.dart';
+import 'domain/usecases/settle_credit_bill.dart';
 import 'presentation/screens/accounts_screen.dart';
 import 'presentation/screens/ledger_screen.dart';
 import 'presentation/screens/reports_screen.dart';
@@ -45,6 +46,7 @@ class VentExpenseApp extends StatelessWidget {
             sl<AccountRepository>(),
             sl<CalculateNetPosition>(),
             sl<ManageAccount>(),
+            sl<SettleCreditBill>(),
           ),
         ),
         ChangeNotifierProvider(

--- a/lib/presentation/providers/account_provider.dart
+++ b/lib/presentation/providers/account_provider.dart
@@ -2,20 +2,24 @@ import 'package:flutter/foundation.dart';
 
 import '../../domain/entities/account.dart';
 import '../../domain/entities/enums.dart';
+import '../../domain/entities/transaction.dart';
 import '../../domain/repositories/account_repository.dart';
 import '../../domain/usecases/calculate_net_position.dart';
 import '../../domain/usecases/manage_account.dart';
+import '../../domain/usecases/settle_credit_bill.dart';
 
 /// Manages account state and net position calculation.
 class AccountProvider extends ChangeNotifier {
   final AccountRepository _accountRepository;
   final CalculateNetPosition _calculateNetPosition;
   final ManageAccount _manageAccount;
+  final SettleCreditBill _settleCreditBill;
 
   AccountProvider(
     this._accountRepository,
     this._calculateNetPosition,
     this._manageAccount,
+    this._settleCreditBill,
   );
 
   List<Account> _accounts = [];
@@ -115,6 +119,29 @@ class AccountProvider extends ChangeNotifier {
     } catch (e) {
       _error = e.toString();
       notifyListeners();
+    }
+  }
+
+  /// Settles a credit card bill and refreshes the list.
+  ///
+  /// Returns the settlement [Transaction] on success, or `null` on failure.
+  Future<Transaction?> settleBill({
+    required String sourceAccountId,
+    required String creditAccountId,
+    required int amount,
+  }) async {
+    try {
+      final txn = await _settleCreditBill.call(
+        sourceAccountId: sourceAccountId,
+        creditAccountId: creditAccountId,
+        amount: amount,
+      );
+      await loadAccounts();
+      return txn;
+    } catch (e) {
+      _error = e.toString();
+      notifyListeners();
+      return null;
     }
   }
 }

--- a/lib/presentation/widgets/account_card.dart
+++ b/lib/presentation/widgets/account_card.dart
@@ -10,16 +10,19 @@ import '../../domain/value_objects/money.dart';
 ///
 /// - Tap to edit
 /// - Long press to archive
+/// - Optional "Pay" button for credit accounts
 class AccountCard extends StatelessWidget {
   final Account account;
   final VoidCallback? onTap;
   final VoidCallback? onLongPress;
+  final VoidCallback? onPayBill;
 
   const AccountCard({
     super.key,
     required this.account,
     this.onTap,
     this.onLongPress,
+    this.onPayBill,
   });
 
   @override
@@ -93,6 +96,30 @@ class AccountCard extends StatelessWidget {
                     ],
                   ),
                 ),
+
+                // — Pay Bill button (credit accounts only) —
+                if (onPayBill != null) ...[
+                  const SizedBox(width: 8),
+                  SizedBox(
+                    width: 36,
+                    height: 36,
+                    child: Material(
+                      color: AppColors.transferAmber.withValues(alpha: 0.1),
+                      borderRadius: BorderRadius.circular(8),
+                      child: InkWell(
+                        onTap: onPayBill,
+                        borderRadius: BorderRadius.circular(8),
+                        child: const Icon(
+                          Icons.payments_outlined,
+                          color: AppColors.transferAmber,
+                          size: 18,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+
+                const SizedBox(width: 8),
 
                 // — Balance —
                 Text(

--- a/lib/presentation/widgets/pay_bill_sheet.dart
+++ b/lib/presentation/widgets/pay_bill_sheet.dart
@@ -1,0 +1,383 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../core/theme/app_colors.dart';
+import '../../core/theme/app_typography.dart';
+import '../../domain/entities/account.dart';
+import '../../domain/value_objects/money.dart';
+
+/// Bottom sheet for one-touch credit card bill settlement.
+///
+/// Shows the credit card's outstanding balance, lets the user pick a source
+/// asset account, enter an amount (or tap "Pay Full Balance"), and settle.
+class PayBillSheet extends StatefulWidget {
+  /// The credit card account to pay.
+  final Account creditAccount;
+
+  /// Available source accounts (assets only, non-archived).
+  final List<Account> assetAccounts;
+
+  const PayBillSheet({
+    super.key,
+    required this.creditAccount,
+    required this.assetAccounts,
+  });
+
+  @override
+  State<PayBillSheet> createState() => _PayBillSheetState();
+}
+
+class _PayBillSheetState extends State<PayBillSheet> {
+  String? _selectedSourceId;
+  final _amountController = TextEditingController();
+  String? _errorText;
+
+  @override
+  void initState() {
+    super.initState();
+    // Pre-select the first asset account if available
+    if (widget.assetAccounts.isNotEmpty) {
+      _selectedSourceId = widget.assetAccounts.first.id;
+    }
+    // Pre-fill with full outstanding balance
+    _amountController.text = widget.creditAccount.balance.toString();
+  }
+
+  @override
+  void dispose() {
+    _amountController.dispose();
+    super.dispose();
+  }
+
+  Account? get _selectedSource {
+    if (_selectedSourceId == null) return null;
+    try {
+      return widget.assetAccounts.firstWhere((a) => a.id == _selectedSourceId);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  void _onPayFullBalance() {
+    _amountController.text = widget.creditAccount.balance.toString();
+    setState(() => _errorText = null);
+  }
+
+  void _onSettle() {
+    final amountText = _amountController.text.trim();
+    final amount = int.tryParse(amountText);
+
+    if (_selectedSourceId == null) {
+      setState(() => _errorText = 'Select a source account');
+      return;
+    }
+    if (amount == null || amount <= 0) {
+      setState(() => _errorText = 'Enter a valid amount');
+      return;
+    }
+
+    final source = _selectedSource;
+    if (source != null && amount > source.balance) {
+      final formatted = Money(cents: source.balance, currency: source.currency).formatted;
+      setState(() => _errorText = 'Insufficient balance ($formatted available)');
+      return;
+    }
+
+    if (amount > widget.creditAccount.balance) {
+      final formatted = Money(
+        cents: widget.creditAccount.balance,
+        currency: widget.creditAccount.currency,
+      ).formatted;
+      setState(() =>
+          _errorText = 'Amount exceeds outstanding balance ($formatted)');
+      return;
+    }
+
+    // Return result
+    Navigator.of(context).pop({
+      'sourceAccountId': _selectedSourceId,
+      'creditAccountId': widget.creditAccount.id,
+      'amount': amount,
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final outstandingBalance = Money(
+      cents: widget.creditAccount.balance,
+      currency: widget.creditAccount.currency,
+    );
+
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 24,
+        right: 24,
+        top: 20,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 24,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // — Handle bar —
+          Center(
+            child: Container(
+              width: 36,
+              height: 4,
+              decoration: BoxDecoration(
+                color: AppColors.divider,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+
+          // — Header —
+          Row(
+            children: [
+              Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  color: AppColors.transferAmber.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: const Icon(
+                  Icons.payments_outlined,
+                  color: AppColors.transferAmber,
+                  size: 22,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Pay Bill',
+                      style: AppTypography.titleLarge.copyWith(
+                        color: AppColors.inkBlue,
+                      ),
+                    ),
+                    Text(
+                      widget.creditAccount.name,
+                      style: AppTypography.bodySmall,
+                    ),
+                  ],
+                ),
+              ),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Text(
+                    'OUTSTANDING',
+                    style: AppTypography.label.copyWith(
+                      fontSize: 9,
+                      letterSpacing: 1.5,
+                      color: AppColors.stampRed,
+                    ),
+                  ),
+                  Text(
+                    outstandingBalance.formatted,
+                    style: AppTypography.amountMedium.copyWith(
+                      color: AppColors.stampRed,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          const SizedBox(height: 24),
+
+          // — Source Account Label —
+          Text(
+            'PAY FROM',
+            style: AppTypography.label.copyWith(
+              letterSpacing: 2.0,
+              color: AppColors.inkLight,
+            ),
+          ),
+          const SizedBox(height: 8),
+
+          // — Source Account Chips —
+          if (widget.assetAccounts.isEmpty)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: Text(
+                'No asset accounts available',
+                style: AppTypography.bodySmall.copyWith(
+                  color: AppColors.disabled,
+                  fontStyle: FontStyle.italic,
+                ),
+              ),
+            )
+          else
+            Wrap(
+              spacing: 8,
+              runSpacing: 6,
+              children: widget.assetAccounts.map((account) {
+                final isSelected = account.id == _selectedSourceId;
+                final balance = Money(
+                  cents: account.balance,
+                  currency: account.currency,
+                );
+                return ChoiceChip(
+                  label: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        account.name,
+                        style: AppTypography.bodySmall.copyWith(
+                          color: isSelected
+                              ? AppColors.paper
+                              : AppColors.inkDark,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      Text(
+                        balance.formatted,
+                        style: AppTypography.label.copyWith(
+                          fontSize: 10,
+                          color: isSelected
+                              ? AppColors.paper.withValues(alpha: 0.8)
+                              : AppColors.inkGreen,
+                        ),
+                      ),
+                    ],
+                  ),
+                  selected: isSelected,
+                  onSelected: (_) {
+                    setState(() {
+                      _selectedSourceId = account.id;
+                      _errorText = null;
+                    });
+                  },
+                  selectedColor: AppColors.inkGreen,
+                  backgroundColor: AppColors.inkGreenLight,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    side: BorderSide(
+                      color: isSelected
+                          ? AppColors.inkGreen
+                          : AppColors.divider,
+                    ),
+                  ),
+                  showCheckmark: false,
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                );
+              }).toList(),
+            ),
+          const SizedBox(height: 20),
+
+          // — Amount Label + Pay Full Balance —
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'AMOUNT',
+                style: AppTypography.label.copyWith(
+                  letterSpacing: 2.0,
+                  color: AppColors.inkLight,
+                ),
+              ),
+              GestureDetector(
+                onTap: _onPayFullBalance,
+                child: Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: AppColors.transferAmber.withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(6),
+                    border: Border.all(
+                      color: AppColors.transferAmber.withValues(alpha: 0.3),
+                    ),
+                  ),
+                  child: Text(
+                    'Pay Full Balance',
+                    style: AppTypography.label.copyWith(
+                      color: AppColors.transferAmber,
+                      fontSize: 10,
+                      letterSpacing: 0.5,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+
+          // — Amount Input —
+          TextField(
+            controller: _amountController,
+            keyboardType: TextInputType.number,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            style: AppTypography.amountLarge.copyWith(
+              color: AppColors.inkDark,
+              fontSize: 24,
+            ),
+            decoration: InputDecoration(
+              prefixText: 'Rp ',
+              prefixStyle: AppTypography.amountLarge.copyWith(
+                color: AppColors.inkLight,
+                fontSize: 24,
+              ),
+              hintText: '0',
+              hintStyle: AppTypography.amountLarge.copyWith(
+                color: AppColors.disabled,
+                fontSize: 24,
+              ),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(10),
+                borderSide: const BorderSide(color: AppColors.divider),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(10),
+                borderSide: const BorderSide(
+                  color: AppColors.transferAmber,
+                  width: 1.5,
+                ),
+              ),
+              contentPadding:
+                  const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+              errorText: _errorText,
+              errorStyle: AppTypography.bodySmall.copyWith(
+                color: AppColors.error,
+              ),
+            ),
+            onChanged: (_) {
+              if (_errorText != null) setState(() => _errorText = null);
+            },
+          ),
+          const SizedBox(height: 24),
+
+          // — Settle Button —
+          SizedBox(
+            width: double.infinity,
+            height: 50,
+            child: ElevatedButton.icon(
+              onPressed: widget.assetAccounts.isEmpty ? null : _onSettle,
+              icon: const Icon(Icons.check_circle_outline, size: 20),
+              label: Text(
+                'Settle',
+                style: AppTypography.titleMedium.copyWith(
+                  color: AppColors.paper,
+                ),
+              ),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.transferAmber,
+                foregroundColor: AppColors.paper,
+                disabledBackgroundColor: AppColors.disabled,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                elevation: 0,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/domain/usecases/settle_credit_bill_test.dart
+++ b/test/domain/usecases/settle_credit_bill_test.dart
@@ -1,0 +1,272 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vent_expense_pro/domain/entities/account.dart';
+import 'package:vent_expense_pro/domain/entities/enums.dart';
+import 'package:vent_expense_pro/domain/entities/transaction.dart';
+import 'package:vent_expense_pro/domain/repositories/account_repository.dart';
+import 'package:vent_expense_pro/domain/repositories/transaction_repository.dart';
+import 'package:vent_expense_pro/domain/usecases/settle_credit_bill.dart';
+
+// ——— In-memory fakes ———
+
+class FakeAccountRepository implements AccountRepository {
+  final Map<String, Account> _accounts = {};
+
+  void seed(List<Account> accounts) {
+    for (final a in accounts) {
+      _accounts[a.id] = a;
+    }
+  }
+
+  Account? accountById(String id) => _accounts[id];
+
+  @override
+  Future<List<Account>> getAll() async => _accounts.values.toList();
+
+  @override
+  Future<Account?> getById(String id) async => _accounts[id];
+
+  @override
+  Future<Account> insert(Account account) async {
+    _accounts[account.id] = account;
+    return account;
+  }
+
+  @override
+  Future<Account> update(Account account) async {
+    _accounts[account.id] = account;
+    return account;
+  }
+
+  @override
+  Future<void> updateBalance(String id, int newBalance) async {
+    final account = _accounts[id]!;
+    _accounts[id] = account.copyWith(balance: newBalance);
+  }
+
+  @override
+  Future<void> archive(String id) async {
+    final account = _accounts[id]!;
+    _accounts[id] = account.copyWith(isArchived: true);
+  }
+
+  @override
+  Future<List<Account>> getByType(AccountType type) async =>
+      _accounts.values.where((a) => a.type == type).toList();
+}
+
+class FakeTransactionRepository implements TransactionRepository {
+  final Map<String, Transaction> _transactions = {};
+
+  @override
+  Future<List<Transaction>> getAll() async =>
+      _transactions.values.toList()
+        ..sort((a, b) => b.dateTime.compareTo(a.dateTime));
+
+  @override
+  Future<List<Transaction>> getByAccount(String accountId) async =>
+      _transactions.values
+          .where((t) => t.accountId == accountId || t.toAccountId == accountId)
+          .toList();
+
+  @override
+  Future<List<Transaction>> getByDateRange(
+      DateTime start, DateTime end) async =>
+      _transactions.values
+          .where((t) =>
+              t.dateTime.isAfter(start.subtract(const Duration(seconds: 1))) &&
+              t.dateTime.isBefore(end.add(const Duration(seconds: 1))))
+          .toList();
+
+  @override
+  Future<Transaction?> getById(String id) async => _transactions[id];
+
+  @override
+  Future<Transaction> insert(Transaction transaction) async {
+    _transactions[transaction.id] = transaction;
+    return transaction;
+  }
+
+  @override
+  Future<Transaction> update(Transaction transaction) async {
+    _transactions[transaction.id] = transaction;
+    return transaction;
+  }
+
+  @override
+  Future<void> delete(String id) async {
+    _transactions.remove(id);
+  }
+}
+
+// ——— Tests ———
+
+void main() {
+  late FakeAccountRepository accountRepo;
+  late FakeTransactionRepository transactionRepo;
+  late SettleCreditBill settleCreditBill;
+
+  final now = DateTime(2026, 2, 21, 14, 30);
+
+  final debitAccount = Account(
+    id: 'acc-debit',
+    name: 'BCA Debit',
+    type: AccountType.debit,
+    balance: 500000,
+    currency: 'IDR',
+    createdAt: now,
+  );
+
+  final cashAccount = Account(
+    id: 'acc-cash',
+    name: 'Cash Wallet',
+    type: AccountType.cash,
+    balance: 200000,
+    currency: 'IDR',
+    createdAt: now,
+  );
+
+  final creditAccount = Account(
+    id: 'acc-credit',
+    name: 'BCA Credit Card',
+    type: AccountType.credit,
+    balance: 150000, // Rp 150,000 outstanding
+    currency: 'IDR',
+    createdAt: now,
+  );
+
+  setUp(() {
+    accountRepo = FakeAccountRepository();
+    transactionRepo = FakeTransactionRepository();
+    settleCreditBill = SettleCreditBill(transactionRepo, accountRepo);
+
+    accountRepo.seed([debitAccount, cashAccount, creditAccount]);
+  });
+
+  group('SettleCreditBill — happy path', () {
+    test('should settle full balance from debit account', () async {
+      final txn = await settleCreditBill.call(
+        sourceAccountId: 'acc-debit',
+        creditAccountId: 'acc-credit',
+        amount: 150000,
+      );
+
+      // Source deducted
+      expect(accountRepo.accountById('acc-debit')!.balance, 350000);
+      // Credit liability cleared
+      expect(accountRepo.accountById('acc-credit')!.balance, 0);
+      // Settlement transaction logged
+      expect(txn.isSettlement, true);
+      expect(txn.type, TransactionType.transfer);
+      expect(txn.amount, 150000);
+      expect(txn.accountId, 'acc-debit');
+      expect(txn.toAccountId, 'acc-credit');
+      expect(txn.categoryId, 'settlement');
+      // Persisted
+      final stored = await transactionRepo.getById(txn.id);
+      expect(stored, isNotNull);
+    });
+
+    test('should settle partial amount', () async {
+      final txn = await settleCreditBill.call(
+        sourceAccountId: 'acc-debit',
+        creditAccountId: 'acc-credit',
+        amount: 50000,
+      );
+
+      expect(accountRepo.accountById('acc-debit')!.balance, 450000);
+      expect(accountRepo.accountById('acc-credit')!.balance, 100000);
+      expect(txn.amount, 50000);
+    });
+
+    test('should settle from cash account', () async {
+      final txn = await settleCreditBill.call(
+        sourceAccountId: 'acc-cash',
+        creditAccountId: 'acc-credit',
+        amount: 100000,
+      );
+
+      expect(accountRepo.accountById('acc-cash')!.balance, 100000);
+      expect(accountRepo.accountById('acc-credit')!.balance, 50000);
+      expect(txn.accountId, 'acc-cash');
+    });
+  });
+
+  group('SettleCreditBill — validation', () {
+    test('should throw when amount is zero', () {
+      expect(
+        () => settleCreditBill.call(
+          sourceAccountId: 'acc-debit',
+          creditAccountId: 'acc-credit',
+          amount: 0,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('should throw when amount is negative', () {
+      expect(
+        () => settleCreditBill.call(
+          sourceAccountId: 'acc-debit',
+          creditAccountId: 'acc-credit',
+          amount: -10000,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('should throw when source is a credit account (not asset)', () {
+      expect(
+        () => settleCreditBill.call(
+          sourceAccountId: 'acc-credit',
+          creditAccountId: 'acc-credit',
+          amount: 50000,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('should throw when target is a debit account (not liability)', () {
+      expect(
+        () => settleCreditBill.call(
+          sourceAccountId: 'acc-debit',
+          creditAccountId: 'acc-cash',
+          amount: 50000,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('should throw when source account not found', () {
+      expect(
+        () => settleCreditBill.call(
+          sourceAccountId: 'nonexistent',
+          creditAccountId: 'acc-credit',
+          amount: 50000,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('should throw when credit account not found', () {
+      expect(
+        () => settleCreditBill.call(
+          sourceAccountId: 'acc-debit',
+          creditAccountId: 'nonexistent',
+          amount: 50000,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('should throw when insufficient balance', () {
+      expect(
+        () => settleCreditBill.call(
+          sourceAccountId: 'acc-debit',
+          creditAccountId: 'acc-credit',
+          amount: 600000, // source only has 500000
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 🎯 Overview

Implements **§5.3 Smart Settlement — One-Touch Pay Bill** from the PRD. The `SettleCreditBill` domain use case already existed but had no presentation layer wiring — this PR connects it end-to-end with a new Pay Bill bottom sheet, provider integration, and account card affordance.

## ✨ Features

### One-Touch Pay Bill (STL-01)
- **Amber "Pay" button** appears on credit card accounts with outstanding balance > 0
- Tapping opens the `PayBillSheet` bottom sheet

### Pay Bill Sheet (STL-02)
- **Header** showing credit card name + outstanding balance in stamp-red
- **Source account chips** — only non-archived asset accounts (debit/cash) with balance > 0, each displaying name + available balance
- **Amount input** — numeric-only field, pre-filled with full outstanding balance
- **"Pay Full Balance" chip** — one-tap shortcut to fill the full credit balance
- **Inline validation**:
  - Amount must be > 0
  - Amount must not exceed source account balance
  - Amount must not exceed outstanding credit balance
- **"Settle" button** — executes settlement, pops sheet

### Balance Integrity (STL-03)
- Source (asset) balance **decreases** by settlement amount
- Credit (liability) balance **decreases** by settlement amount
- Settlement logged as a `transfer` transaction with `isSettlement: true` and `categoryId: 'settlement'`
- Auto-generated note: `Bill payment: Source → Credit`

### Post-Settlement UX
- **Success snackbar** — shows settled amount with ✓
- **Error snackbar** — shows error message on failure
- **Account balances** refresh immediately after settlement
- **Ledger feed** refreshes — settlement transaction appears with `⇄` icon in amber

## 📁 Files Changed (6 files, +400 / -8)

### New Files (2)
| File | Purpose |
|------|---------| 
| `lib/presentation/widgets/pay_bill_sheet.dart` | Pay Bill bottom sheet UI |
| `test/domain/usecases/settle_credit_bill_test.dart` | 10 unit tests for `SettleCreditBill` |

### Modified Files (4)
| File | Changes |
|------|---------|
| `lib/presentation/providers/account_provider.dart` | Added `SettleCreditBill` dependency + `settleBill()` method |
| `lib/main.dart` | Inject `sl<SettleCreditBill>()` into `AccountProvider` |
| `lib/presentation/widgets/account_card.dart` | Added `onPayBill` callback + amber pay icon button |
| `lib/presentation/screens/accounts_screen.dart` | Wire `PayBillSheet`, success/error snackbars, ledger refresh |

## 🏗 Architecture

```
┌──────────────────────────────────────────────────┐
│ Presentation                                      │
│  AccountsScreen → _showPayBillSheet()            │
│  PayBillSheet (source chips, amount, validate)   │
│  AccountCard (onPayBill → amber button)          │
│  AccountProvider.settleBill()                     │
├──────────────────────────────────────────────────┤
│ Domain                                            │
│  SettleCreditBill.call()   [already existed]      │
│  └── Validate source/target/amount               │
│  └── Deduct asset, reduce liability              │
│  └── Log settlement transaction                  │
├──────────────────────────────────────────────────┤
│ Data                                              │
│  AccountRepository.updateBalance()               │
│  TransactionRepository.insert()                  │
└──────────────────────────────────────────────────┘
```

## ✅ Testing

- **Unit tests**: 62/62 pass (`flutter test`)
  - 10 new tests for `SettleCreditBill`: happy path (3), validation (7)
  - Covers: full balance, partial amount, cash source, zero/negative amount, wrong account types, not found, insufficient balance
- **Static analysis**: `flutter analyze` — 0 errors, 0 warnings
- **Manual testing**: Verified on Android emulator (Pixel 8 Pro)

## 🔗 Related

- Closes STL-01: Pay Bill button on credit accounts
- Closes STL-02: Pay Bill bottom sheet with validation
- Closes STL-03: Balance integrity for settlements
- Depends on: §5.1 Account Management (accounts must exist)
- Depends on: §5.2 Transaction Logging (settlement appears in ledger feed)
