### PR TITLE
Merge bank ready reports into 1.0.0

### DIFF
--- a/lib/core/di/service_locator.dart
+++ b/lib/core/di/service_locator.dart
@@ -15,6 +15,11 @@ import '../../domain/usecases/manage_account.dart';
 import '../../domain/usecases/manage_transaction.dart';
 import '../../domain/usecases/settle_credit_bill.dart';
 import '../../domain/usecases/sync_data.dart';
+import '../../domain/usecases/generate_report.dart';
+import '../../domain/repositories/report_repository.dart';
+import '../../data/repositories/report_repository_impl.dart';
+import '../../data/datasources/pdf_report_service.dart';
+import '../../data/datasources/excel_report_service.dart';
 
 /// Global service locator instance.
 final sl = GetIt.instance;
@@ -32,6 +37,16 @@ Future<void> initServiceLocator() async {
   sl.registerLazySingleton(() => GoogleDriveService());
   sl.registerLazySingleton<SyncRepository>(
     () => SyncRepositoryImpl(sl<GoogleDriveService>()),
+  );
+
+  // — Reports —
+  sl.registerLazySingleton(() => PdfReportService());
+  sl.registerLazySingleton(() => ExcelReportService());
+  sl.registerLazySingleton<ReportRepository>(
+    () => ReportRepositoryImpl(
+      pdfService: sl<PdfReportService>(),
+      excelService: sl<ExcelReportService>(),
+    ),
   );
 
   // — Use Cases —
@@ -52,4 +67,12 @@ Future<void> initServiceLocator() async {
     ),
   );
   sl.registerFactory(() => SyncData(sl<SyncRepository>()));
+  sl.registerFactory(
+    () => GenerateReport(
+      reportRepository: sl<ReportRepository>(),
+      transactionRepository: sl<TransactionRepository>(),
+      accountRepository: sl<AccountRepository>(),
+      categoryRepository: sl<CategoryRepository>(),
+    ),
+  );
 }

--- a/lib/data/datasources/excel_report_service.dart
+++ b/lib/data/datasources/excel_report_service.dart
@@ -1,0 +1,82 @@
+import 'dart:io';
+import 'package:excel/excel.dart';
+import 'package:intl/intl.dart';
+import 'package:path_provider/path_provider.dart';
+
+import '../../domain/entities/account.dart';
+import '../../domain/entities/category.dart';
+import '../../domain/entities/enums.dart';
+import '../../domain/entities/transaction.dart';
+import '../models/category_model.dart';
+
+class ExcelReportService {
+  Future<String> generate({
+    required List<Transaction> transactions,
+    required List<Account> accounts,
+    required List<Category> categories,
+    String? accountId,
+    DateTime? startDate,
+    DateTime? endDate,
+  }) async {
+    final excel = Excel.createExcel();
+    final Sheet sheet = excel['Ledger Report'];
+
+    final accountName = accountId != null 
+        ? accounts.firstWhere((a) => a.id == accountId).name 
+        : 'All accounts';
+
+    // Summary Header
+    sheet.appendRow([TextCellValue('VentExpense Pro Ledger Statement')]);
+    sheet.appendRow([TextCellValue('Account: $accountName')]);
+    sheet.appendRow([
+      TextCellValue('Period: ${startDate != null ? DateFormat('dd/MM/yyyy').format(startDate) : 'Start'} - ${endDate != null ? DateFormat('dd/MM/yyyy').format(endDate) : 'Present'}')
+    ]);
+    sheet.appendRow([]); // Empty spacer
+
+    // Table Header
+    sheet.appendRow([
+      TextCellValue('Date'),
+      TextCellValue('Type'),
+      TextCellValue('Category'),
+      TextCellValue('Account'),
+      TextCellValue('To Account'),
+      TextCellValue('Note'),
+      TextCellValue('Amount'),
+      TextCellValue('Is Settlement'),
+    ]);
+
+    // Data Rows
+    for (final t in transactions) {
+      final category = categories.firstWhere(
+        (c) => c.id == t.categoryId,
+        orElse: () => const CategoryModel(id: '?', name: 'Unknown', icon: '?'),
+      );
+      final account = accounts.firstWhere((a) => a.id == t.accountId);
+      final toAccount = t.toAccountId != null 
+          ? accounts.firstWhere((a) => a.id == t.toAccountId).name 
+          : '-';
+
+      sheet.appendRow([
+        TextCellValue(DateFormat('yyyy-MM-dd HH:mm').format(t.dateTime)),
+        TextCellValue(t.type.toString().split('.').last.toUpperCase()),
+        TextCellValue(category.name),
+        TextCellValue(account.name),
+        TextCellValue(toAccount),
+        TextCellValue(t.note ?? ''),
+        IntCellValue(t.type == TransactionType.expense ? -t.amount : t.amount),
+        TextCellValue(t.isSettlement ? 'Yes' : 'No'),
+      ]);
+    }
+
+    final output = await getTemporaryDirectory();
+    final fileName = 'vent_report_${DateTime.now().millisecondsSinceEpoch}.xlsx';
+    final path = '${output.path}/$fileName';
+    
+    final fileBytes = excel.save();
+    if (fileBytes != null) {
+      await File(path).writeAsBytes(fileBytes);
+    }
+
+    return path;
+  }
+}

--- a/lib/data/datasources/pdf_report_service.dart
+++ b/lib/data/datasources/pdf_report_service.dart
@@ -1,0 +1,221 @@
+import 'dart:io';
+import 'package:flutter/services.dart';
+import 'package:intl/intl.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:pdf/pdf.dart';
+import 'package:pdf/widgets.dart' as pw;
+
+import '../../domain/entities/account.dart';
+import '../../domain/entities/category.dart';
+import '../../domain/entities/enums.dart';
+import '../../domain/entities/transaction.dart';
+import '../models/category_model.dart';
+
+class PdfReportService {
+  static const PdfColor _paper = PdfColor.fromInt(0xFFFFF8F0);
+  static const PdfColor _inkBlue = PdfColor.fromInt(0xFF1B3A5C);
+  static const PdfColor _inkDark = PdfColor.fromInt(0xFF2C2C2C);
+  static const PdfColor _inkLight = PdfColor.fromInt(0xFF7A7570);
+  static const PdfColor _stampRed = PdfColor.fromInt(0xFFC0392B);
+  static const PdfColor _inkGreen = PdfColor.fromInt(0xFF27774E);
+
+  Future<String> generate({
+    required List<Transaction> transactions,
+    required List<Account> accounts,
+    required List<Category> categories,
+    String? accountId,
+    DateTime? startDate,
+    DateTime? endDate,
+  }) async {
+    final pdf = pw.Document();
+
+    // Load fonts
+    final loraRegular = pw.Font.ttf(await rootBundle.load('assets/fonts/Lora-Regular.ttf'));
+    final loraBold = pw.Font.ttf(await rootBundle.load('assets/fonts/Lora-Bold.ttf'));
+    final monoRegular = pw.Font.ttf(await rootBundle.load('assets/fonts/JetBrainsMono-Regular.ttf'));
+
+    final DateFormat formatter = DateFormat('dd MMM yyyy');
+    final NumberFormat currencyFormatter = NumberFormat.currency(
+      symbol: '',
+      decimalDigits: 0,
+    );
+
+    final accountName = accountId != null 
+        ? accounts.firstWhere((a) => a.id == accountId).name 
+        : 'All accounts';
+
+    final dateRangeStr = (startDate != null && endDate != null)
+        ? '${formatter.format(startDate)} - ${formatter.format(endDate)}'
+        : 'All Time';
+
+    pdf.addPage(
+      pw.MultiPage(
+        pageTheme: pw.PageTheme(
+          pageFormat: PdfPageFormat.a4,
+          buildBackground: (context) => pw.FullPage(
+            ignoreMargins: true,
+            child: pw.Container(color: _paper),
+          ),
+        ),
+        header: (context) => pw.Column(
+          crossAxisAlignment: pw.CrossAxisAlignment.start,
+          children: [
+            pw.Row(
+              mainAxisAlignment: pw.MainAxisAlignment.spaceBetween,
+              children: [
+                pw.Text(
+                  'VENTEXPENSE PRO',
+                  style: pw.TextStyle(
+                    font: loraBold,
+                    fontSize: 24,
+                    color: _inkBlue,
+                  ),
+                ),
+                pw.Text(
+                  'LEDGER STATEMENT',
+                  style: pw.TextStyle(
+                    font: monoRegular,
+                    fontSize: 10,
+                    color: _inkLight,
+                  ),
+                ),
+              ],
+            ),
+            pw.SizedBox(height: 8),
+            pw.Divider(color: _inkBlue, thickness: 1),
+            pw.SizedBox(height: 16),
+            pw.Row(
+              crossAxisAlignment: pw.CrossAxisAlignment.start,
+              children: [
+                pw.Expanded(
+                  child: pw.Column(
+                    crossAxisAlignment: pw.CrossAxisAlignment.start,
+                    children: [
+                      _label('ACCOUNT', loraBold),
+                      pw.Text(accountName, style: pw.TextStyle(font: loraRegular, fontSize: 14)),
+                    ],
+                  ),
+                ),
+                pw.Expanded(
+                  child: pw.Column(
+                    crossAxisAlignment: pw.CrossAxisAlignment.start,
+                    children: [
+                      _label('PERIOD', loraBold),
+                      pw.Text(dateRangeStr, style: pw.TextStyle(font: loraRegular, fontSize: 14)),
+                    ],
+                  ),
+                ),
+                pw.Expanded(
+                  child: pw.Column(
+                    crossAxisAlignment: pw.CrossAxisAlignment.start,
+                    children: [
+                      _label('GENERATED AT', loraBold),
+                      pw.Text(formatter.format(DateTime.now()), style: pw.TextStyle(font: loraRegular, fontSize: 14)),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            pw.SizedBox(height: 24),
+          ],
+        ),
+        build: (context) => [
+          pw.Table(
+            border: const pw.TableBorder(
+              bottom: pw.BorderSide(color: _inkLight, width: 0.5),
+              horizontalInside: pw.BorderSide(color: _inkLight, width: 0.2),
+            ),
+            columnWidths: {
+              0: const pw.FlexColumnWidth(2), // Date
+              1: const pw.FlexColumnWidth(3), // Category
+              2: const pw.FlexColumnWidth(4), // Note
+              3: const pw.FlexColumnWidth(2.5), // Amount
+            },
+            children: [
+              // Header
+              pw.TableRow(
+                decoration: const pw.BoxDecoration(color: PdfColors.grey200),
+                children: [
+                  _tableHeader('DATE', monoRegular),
+                  _tableHeader('CATEGORY', monoRegular),
+                  _tableHeader('NOTE', monoRegular),
+                  _tableHeader('AMOUNT', monoRegular, align: pw.Alignment.centerRight),
+                ],
+              ),
+              // Data
+              ...transactions.map((t) {
+                final category = categories.firstWhere(
+                  (c) => c.id == t.categoryId,
+                  orElse: () => const CategoryModel(id: '?', name: 'Unknown', icon: '?'),
+                );
+                final isPositive = t.type == TransactionType.income;
+                final amountColor = isPositive ? _inkGreen : _stampRed;
+                final amountPrefix = isPositive ? '+' : '-';
+
+                return pw.TableRow(
+                  children: [
+                    _tableCell(DateFormat('dd/MM/yy').format(t.dateTime), loraRegular),
+                    _tableCell(category.name, loraRegular),
+                    _tableCell(t.note ?? '-', loraRegular),
+                    _tableCell(
+                      '$amountPrefix${currencyFormatter.format(t.amount)}',
+                      monoRegular,
+                      color: amountColor,
+                      align: pw.Alignment.centerRight,
+                    ),
+                  ],
+                );
+              }).toList(),
+            ],
+          ),
+        ],
+        footer: (context) => pw.Container(
+          alignment: pw.Alignment.centerRight,
+          margin: const pw.EdgeInsets.only(top: 10),
+          child: pw.Text(
+            'Page ${context.pageNumber} of ${context.pagesCount}',
+            style: pw.TextStyle(font: loraRegular, fontSize: 10, color: _inkLight),
+          ),
+        ),
+      ),
+    );
+
+    final output = await getTemporaryDirectory();
+    final fileName = 'vent_report_${DateTime.now().millisecondsSinceEpoch}.pdf';
+    final file = File('${output.path}/$fileName');
+    await file.writeAsBytes(await pdf.save());
+    return file.path;
+  }
+
+  pw.Widget _label(String text, pw.Font font) {
+    return pw.Padding(
+      padding: const pw.EdgeInsets.only(bottom: 2),
+      child: pw.Text(
+        text,
+        style: pw.TextStyle(font: font, fontSize: 8, color: _inkLight, letterSpacing: 1.2),
+      ),
+    );
+  }
+
+  pw.Widget _tableHeader(String text, pw.Font font, {pw.Alignment align = pw.Alignment.centerLeft}) {
+    return pw.Container(
+      alignment: align,
+      padding: const pw.EdgeInsets.all(6),
+      child: pw.Text(
+        text,
+        style: pw.TextStyle(font: font, fontSize: 9, fontWeight: pw.FontWeight.bold, color: _inkDark),
+      ),
+    );
+  }
+
+  pw.Widget _tableCell(String text, pw.Font font, {pw.Alignment align = pw.Alignment.centerLeft, PdfColor color = _inkDark}) {
+    return pw.Container(
+      alignment: align,
+      padding: const pw.EdgeInsets.all(6),
+      child: pw.Text(
+        text,
+        style: pw.TextStyle(font: font, fontSize: 10, color: color),
+      ),
+    );
+  }
+}

--- a/lib/data/repositories/report_repository_impl.dart
+++ b/lib/data/repositories/report_repository_impl.dart
@@ -1,0 +1,54 @@
+import '../datasources/excel_report_service.dart';
+import '../datasources/pdf_report_service.dart';
+import '../../domain/entities/account.dart';
+import '../../domain/entities/category.dart';
+import '../../domain/entities/transaction.dart';
+import '../../domain/repositories/report_repository.dart';
+
+class ReportRepositoryImpl implements ReportRepository {
+  final PdfReportService pdfService;
+  final ExcelReportService excelService;
+
+  ReportRepositoryImpl({
+    required this.pdfService,
+    required this.excelService,
+  });
+
+  @override
+  Future<String> generatePdf({
+    required List<Transaction> transactions,
+    required List<Account> accounts,
+    required List<Category> categories,
+    String? accountId,
+    DateTime? startDate,
+    DateTime? endDate,
+  }) {
+    return pdfService.generate(
+      transactions: transactions,
+      accounts: accounts,
+      categories: categories,
+      accountId: accountId,
+      startDate: startDate,
+      endDate: endDate,
+    );
+  }
+
+  @override
+  Future<String> generateExcel({
+    required List<Transaction> transactions,
+    required List<Account> accounts,
+    required List<Category> categories,
+    String? accountId,
+    DateTime? startDate,
+    DateTime? endDate,
+  }) {
+    return excelService.generate(
+      transactions: transactions,
+      accounts: accounts,
+      categories: categories,
+      accountId: accountId,
+      startDate: startDate,
+      endDate: endDate,
+    );
+  }
+}

--- a/lib/domain/repositories/report_repository.dart
+++ b/lib/domain/repositories/report_repository.dart
@@ -1,0 +1,26 @@
+import '../entities/account.dart';
+import '../entities/category.dart';
+import '../entities/transaction.dart';
+
+/// Contract for generating platform-specific report files.
+abstract class ReportRepository {
+  /// Generates a PDF statement. Returns the file path of the generated report.
+  Future<String> generatePdf({
+    required List<Transaction> transactions,
+    required List<Account> accounts,
+    required List<Category> categories,
+    String? accountId,
+    DateTime? startDate,
+    DateTime? endDate,
+  });
+
+  /// Generates an Excel spreadsheet. Returns the file path of the generated report.
+  Future<String> generateExcel({
+    required List<Transaction> transactions,
+    required List<Account> accounts,
+    required List<Category> categories,
+    String? accountId,
+    DateTime? startDate,
+    DateTime? endDate,
+  });
+}

--- a/lib/domain/usecases/generate_report.dart
+++ b/lib/domain/usecases/generate_report.dart
@@ -1,0 +1,67 @@
+import '../repositories/report_repository.dart';
+import '../repositories/transaction_repository.dart';
+import '../repositories/account_repository.dart';
+import '../repositories/category_repository.dart';
+
+/// Orchestrates the generation of bank-ready reports.
+class GenerateReport {
+  final ReportRepository reportRepository;
+  final TransactionRepository transactionRepository;
+  final AccountRepository accountRepository;
+  final CategoryRepository categoryRepository;
+
+  GenerateReport({
+    required this.reportRepository,
+    required this.transactionRepository,
+    required this.accountRepository,
+    required this.categoryRepository,
+  });
+
+  /// Generates a report of the specified [type] ('pdf' or 'excel').
+  Future<String> call({
+    required String type,
+    String? accountId,
+    DateTime? startDate,
+    DateTime? endDate,
+  }) async {
+    // 1. Fetch all required data
+    final transactions = await transactionRepository.getAll();
+    final accounts = await accountRepository.getAll();
+    final categories = await categoryRepository.getAll();
+
+    // 2. Filter transactions based on criteria
+    final filteredTransactions = transactions.where((t) {
+      if (accountId != null && t.accountId != accountId && t.toAccountId != accountId) {
+        return false;
+      }
+      if (startDate != null && t.dateTime.isBefore(startDate)) {
+        return false;
+      }
+      if (endDate != null && t.dateTime.isAfter(endDate)) {
+        return false;
+      }
+      return true;
+    }).toList();
+
+    // 3. Delegate to repository
+    if (type.toLowerCase() == 'pdf') {
+      return reportRepository.generatePdf(
+        transactions: filteredTransactions,
+        accounts: accounts,
+        categories: categories,
+        accountId: accountId,
+        startDate: startDate,
+        endDate: endDate,
+      );
+    } else {
+      return reportRepository.generateExcel(
+        transactions: filteredTransactions,
+        accounts: accounts,
+        categories: categories,
+        accountId: accountId,
+        startDate: startDate,
+        endDate: endDate,
+      );
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,8 +16,10 @@ import 'domain/usecases/manage_account.dart';
 import 'domain/usecases/manage_transaction.dart';
 import 'domain/usecases/settle_credit_bill.dart';
 import 'domain/usecases/sync_data.dart';
+import 'domain/usecases/generate_report.dart';
 import 'presentation/providers/account_provider.dart';
 import 'presentation/providers/category_provider.dart';
+import 'presentation/providers/reports_provider.dart';
 import 'presentation/providers/sync_provider.dart';
 import 'presentation/providers/transaction_provider.dart';
 import 'presentation/screens/accounts_screen.dart';
@@ -64,6 +66,9 @@ class VentExpenseApp extends StatelessWidget {
         ),
         ChangeNotifierProvider(
           create: (_) => SyncProvider(sl<SyncData>()),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => ReportsProvider(sl<GenerateReport>()),
         ),
       ],
       child: MaterialApp(

--- a/lib/presentation/providers/reports_provider.dart
+++ b/lib/presentation/providers/reports_provider.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import '../../domain/usecases/generate_report.dart';
+
+enum ReportStatus { idle, loading, success, error }
+
+class ReportsProvider extends ChangeNotifier {
+  final GenerateReport generateReportUseCase;
+
+  ReportsProvider(this.generateReportUseCase);
+
+  ReportStatus _status = ReportStatus.idle;
+  ReportStatus get status => _status;
+
+  String? _errorMessage;
+  String? get errorMessage => _errorMessage;
+
+  String? _generatedFilePath;
+  String? get generatedFilePath => _generatedFilePath;
+
+  DateTime? _startDate;
+  DateTime? get startDate => _startDate;
+
+  DateTime? _endDate;
+  DateTime? get endDate => _endDate;
+
+  String? _selectedAccountId;
+  String? get selectedAccountId => _selectedAccountId;
+
+  void setDateRange(DateTime? start, DateTime? end) {
+    _startDate = start;
+    _endDate = end;
+    notifyListeners();
+  }
+
+  void setSelectedAccount(String? accountId) {
+    _selectedAccountId = accountId;
+    notifyListeners();
+  }
+
+  Future<void> generate(String type) async {
+    _status = ReportStatus.loading;
+    _errorMessage = null;
+    _generatedFilePath = null;
+    notifyListeners();
+
+    try {
+      final path = await generateReportUseCase(
+        type: type,
+        accountId: _selectedAccountId,
+        startDate: _startDate,
+        endDate: _endDate,
+      );
+      _generatedFilePath = path;
+      _status = ReportStatus.success;
+    } catch (e) {
+      _errorMessage = e.toString();
+      _status = ReportStatus.error;
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  void reset() {
+    _status = ReportStatus.idle;
+    _errorMessage = null;
+    _generatedFilePath = null;
+    notifyListeners();
+  }
+}

--- a/lib/presentation/screens/reports_screen.dart
+++ b/lib/presentation/screens/reports_screen.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import 'package:share_plus/share_plus.dart';
 
 import '../../core/theme/app_colors.dart';
 import '../../core/theme/app_typography.dart';
 import '../painters/paper_background.dart';
+import '../providers/account_provider.dart';
+import '../providers/reports_provider.dart';
 
 /// The reports screen — PDF / Excel generation and viewing.
 class ReportsScreen extends StatelessWidget {
@@ -11,34 +16,341 @@ class ReportsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PaperBackground(
-      child: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(32),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const Icon(
-                Icons.description_outlined,
-                size: 48,
-                color: AppColors.disabled,
-              ),
-              const SizedBox(height: 16),
-              Text(
-                'Reports coming soon',
-                style: AppTypography.bodyLarge.copyWith(
-                  color: AppColors.inkLight,
+      child: Consumer2<ReportsProvider, AccountProvider>(
+        builder: (context, reportsProvider, accountProvider, child) {
+          final DateFormat formatter = DateFormat('dd MMM yyyy');
+          final String dateRangeLabel = reportsProvider.startDate != null &&
+                  reportsProvider.endDate != null
+              ? '${formatter.format(reportsProvider.startDate!)} - ${formatter.format(reportsProvider.endDate!)}'
+              : 'All Time';
+
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Professional Reports',
+                  style: AppTypography.displayMedium,
                 ),
+                const SizedBox(height: 8),
+                Text(
+                  'Generate bank-ready statements and spreadsheets for your records.',
+                  style: AppTypography.bodyMedium.copyWith(color: AppColors.inkLight),
+                ),
+                const SizedBox(height: 32),
+
+                // — Filter Section —
+                _buildSectionTitle('REPORT FILTERS'),
+                const SizedBox(height: 12),
+                
+                // Date Range Selector
+                _buildFilterTile(
+                  context,
+                  label: 'PERIOD',
+                  value: dateRangeLabel,
+                  onTap: () async {
+                    final range = await showDateRangePicker(
+                      context: context,
+                      initialDateRange: reportsProvider.startDate != null &&
+                              reportsProvider.endDate != null
+                          ? DateTimeRange(
+                              start: reportsProvider.startDate!,
+                              end: reportsProvider.endDate!,
+                            )
+                          : null,
+                      firstDate: DateTime(2020),
+                      lastDate: DateTime.now().add(const Duration(days: 1)),
+                      builder: (context, child) {
+                        return Theme(
+                          data: Theme.of(context).copyWith(
+                            colorScheme: ColorScheme.light(
+                              primary: AppColors.inkBlue,
+                              onPrimary: AppColors.paper,
+                              onSurface: AppColors.inkDark,
+                            ),
+                          ),
+                          child: child!,
+                        );
+                      },
+                    );
+                    if (range != null) {
+                      reportsProvider.setDateRange(range.start, range.end);
+                    }
+                  },
+                ),
+                const SizedBox(height: 16),
+
+                // Account Selector
+                _buildFilterTile(
+                  context,
+                  label: 'ACCOUNT',
+                  value: reportsProvider.selectedAccountId == null
+                      ? 'All Accounts'
+                      : accountProvider.accounts
+                          .firstWhere((a) => a.id == reportsProvider.selectedAccountId)
+                          .name,
+                  onTap: () {
+                    _showAccountSelector(context, accountProvider, reportsProvider);
+                  },
+                ),
+
+                const SizedBox(height: 40),
+
+                // — Action Section —
+                _buildSectionTitle('EXPORT FORMATS'),
+                const SizedBox(height: 16),
+
+                if (reportsProvider.status == ReportStatus.loading)
+                  const Center(
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(vertical: 20),
+                      child: CircularProgressIndicator(color: AppColors.inkBlue),
+                    ),
+                  )
+                else ...[
+                  _buildExportButton(
+                    context,
+                    label: 'Generate PDF Statement',
+                    icon: Icons.picture_as_pdf_outlined,
+                    onTap: () => _generate(context, reportsProvider, 'pdf'),
+                  ),
+                  const SizedBox(height: 12),
+                  _buildExportButton(
+                    context,
+                    label: 'Export to Excel (.xlsx)',
+                    icon: Icons.table_chart_outlined,
+                    onTap: () => _generate(context, reportsProvider, 'excel'),
+                  ),
+                ],
+
+                if (reportsProvider.status == ReportStatus.success) ...[
+                  const SizedBox(height: 32),
+                  Container(
+                    padding: const EdgeInsets.all(20),
+                    decoration: BoxDecoration(
+                      color: AppColors.paperElevated,
+                      borderRadius: BorderRadius.circular(16),
+                      border: Border.all(color: AppColors.inkGreen.withValues(alpha: 0.2)),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withValues(alpha: 0.05),
+                          blurRadius: 10,
+                          offset: const Offset(0, 4),
+                        ),
+                      ],
+                    ),
+                    child: Column(
+                      children: [
+                        Row(
+                          children: [
+                            const Icon(Icons.check_circle, color: AppColors.inkGreen, size: 24),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  const Text(
+                                    'Ready to Save!',
+                                    style: TextStyle(
+                                      fontWeight: FontWeight.bold,
+                                      fontSize: 16,
+                                      color: AppColors.inkDark,
+                                    ),
+                                  ),
+                                  Text(
+                                    'Report generated successfully.',
+                                    style: AppTypography.bodySmall.copyWith(color: AppColors.inkLight),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 20),
+                        SizedBox(
+                          width: double.infinity,
+                          height: 50,
+                          child: ElevatedButton.icon(
+                            onPressed: () {
+                              final box = context.findRenderObject() as RenderBox?;
+                              Share.shareXFiles(
+                                [XFile(reportsProvider.generatedFilePath!)],
+                                text: 'VentExpense Report',
+                                sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,
+                              );
+                            },
+                            icon: const Icon(Icons.share, size: 20),
+                            label: const Text('Share or Save to Files'),
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: AppColors.inkBlue,
+                              foregroundColor: AppColors.paper,
+                              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                              elevation: 0,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+
+                if (reportsProvider.status == ReportStatus.error) ...[
+                  const SizedBox(height: 24),
+                  Text(
+                    'Error: ${reportsProvider.errorMessage}',
+                    style: AppTypography.bodySmall.copyWith(color: AppColors.stampRed),
+                  ),
+                ],
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildSectionTitle(String title) {
+    return Text(
+      title,
+      style: AppTypography.label.copyWith(
+        color: AppColors.inkLight,
+        letterSpacing: 2,
+      ),
+    );
+  }
+
+  Widget _buildFilterTile(
+    BuildContext context, {
+    required String label,
+    required String value,
+    required VoidCallback onTap,
+  }) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(12),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        decoration: BoxDecoration(
+          color: AppColors.paperElevated,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: AppColors.divider, width: 0.5),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    label,
+                    style: AppTypography.label.copyWith(fontSize: 9),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    value,
+                    style: AppTypography.titleMedium,
+                  ),
+                ],
               ),
-              const SizedBox(height: 8),
-              const Text(
-                'Generate PDF & Excel ledger statements',
-                style: AppTypography.bodySmall,
-                textAlign: TextAlign.center,
-              ),
-            ],
-          ),
+            ),
+            const Icon(Icons.chevron_right, color: AppColors.inkLight),
+          ],
         ),
       ),
     );
+  }
+
+  Widget _buildExportButton(
+    BuildContext context, {
+    required String label,
+    required IconData icon,
+    required VoidCallback onTap,
+  }) {
+    return SizedBox(
+      width: double.infinity,
+      height: 56,
+      child: OutlinedButton.icon(
+        onPressed: onTap,
+        icon: Icon(icon, size: 20),
+        label: Text(label),
+        style: OutlinedButton.styleFrom(
+          foregroundColor: AppColors.inkBlue,
+          side: const BorderSide(color: AppColors.inkBlue),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          textStyle: AppTypography.titleMedium,
+        ),
+      ),
+    );
+  }
+
+  void _showAccountSelector(
+    BuildContext context,
+    AccountProvider accProvider,
+    ReportsProvider reportsProvider,
+  ) {
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: AppColors.paper,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (context) {
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(height: 12),
+            Container(width: 40, height: 4, decoration: BoxDecoration(color: AppColors.divider, borderRadius: BorderRadius.circular(2))),
+            const SizedBox(height: 16),
+            const Text('Select Account', style: AppTypography.titleLarge),
+            const SizedBox(height: 16),
+            ListTile(
+              title: const Text('All Accounts'),
+              trailing: reportsProvider.selectedAccountId == null ? const Icon(Icons.check, color: AppColors.inkBlue) : null,
+              onTap: () {
+                reportsProvider.setSelectedAccount(null);
+                Navigator.pop(context);
+              },
+            ),
+            const Divider(height: 1),
+            ...accProvider.accounts.map((account) => ListTile(
+                  title: Text(account.name),
+                  trailing: reportsProvider.selectedAccountId == account.id ? const Icon(Icons.check, color: AppColors.inkBlue) : null,
+                  onTap: () {
+                    reportsProvider.setSelectedAccount(account.id);
+                    Navigator.pop(context);
+                  },
+                )),
+            const SizedBox(height: 24),
+          ],
+        );
+      },
+    );
+  }
+
+  void _generate(BuildContext context, ReportsProvider provider, String type) async {
+    await provider.generate(type);
+    if (!context.mounted) return;
+    
+    if (provider.status == ReportStatus.success) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: const Text('Report generated successfully!'),
+          backgroundColor: AppColors.inkGreen,
+          action: SnackBarAction(
+            label: 'OK',
+            textColor: AppColors.paper,
+            onPressed: () {},
+          ),
+        ),
+      );
+    } else if (provider.status == ReportStatus.error) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Failed to generate report: ${provider.errorMessage}'),
+          backgroundColor: AppColors.stampRed,
+        ),
+      );
+    }
   }
 }

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,9 +6,11 @@ import FlutterMacOS
 import Foundation
 
 import google_sign_in_ios
+import share_plus
 import sqflite_darwin
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
+  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -177,6 +177,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+2"
   crypto:
     dependency: transitive
     description:
@@ -656,6 +664,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: "14c8860d4de93d3a7e53af51bff479598c4e999605290756bbbe45cf65b37840"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.1"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   shelf:
     dependency: transitive
     description:
@@ -797,6 +821,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   uuid:
     dependency: "direct main"
     description:
@@ -853,6 +909,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.15.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   # Report Generation (prep — wired in Phase 2)
   pdf: ^3.11.2
   excel: ^4.0.6
+  share_plus: ^12.0.1
 
 dev_dependencies:
   flutter_test:

--- a/test/domain/usecases/generate_report_test.dart
+++ b/test/domain/usecases/generate_report_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vent_expense_pro/domain/entities/account.dart';
+import 'package:vent_expense_pro/domain/entities/category.dart';
+import 'package:vent_expense_pro/domain/entities/enums.dart';
+import 'package:vent_expense_pro/domain/entities/transaction.dart';
+import 'package:vent_expense_pro/domain/repositories/account_repository.dart';
+import 'package:vent_expense_pro/domain/repositories/category_repository.dart';
+import 'package:vent_expense_pro/domain/repositories/report_repository.dart';
+import 'package:vent_expense_pro/domain/repositories/transaction_repository.dart';
+import 'package:vent_expense_pro/domain/usecases/generate_report.dart';
+
+class FakeReportRepository implements ReportRepository {
+  @override
+  Future<String> generateExcel({
+    required List<Transaction> transactions,
+    required List<Account> accounts,
+    required List<Category> categories,
+    String? accountId,
+    DateTime? startDate,
+    DateTime? endDate,
+  }) async => 'excel_path';
+
+  @override
+  Future<String> generatePdf({
+    required List<Transaction> transactions,
+    required List<Account> accounts,
+    required List<Category> categories,
+    String? accountId,
+    DateTime? startDate,
+    DateTime? endDate,
+  }) async => 'pdf_path';
+}
+
+class FakeTransactionRepository implements TransactionRepository {
+  final List<Transaction> txns;
+  FakeTransactionRepository(this.txns);
+  
+  @override
+  Future<List<Transaction>> getAll() async => txns;
+  
+  @override
+  Future<List<Transaction>> getByAccount(String accountId) async => [];
+
+  @override
+  Future<List<Transaction>> getByDateRange(DateTime start, DateTime end) async => [];
+
+  @override
+  Future<Transaction?> getById(String id) async => null;
+
+  @override
+  Future<Transaction> insert(Transaction transaction) async => transaction;
+
+  @override
+  Future<Transaction> update(Transaction transaction) async => transaction;
+
+  @override
+  Future<void> delete(String id) async {}
+}
+
+class FakeAccountRepository implements AccountRepository {
+  @override
+  Future<List<Account>> getAll() async => [];
+
+  @override
+  Future<List<Account>> getByType(AccountType type) async => [];
+
+  @override
+  Future<Account?> getById(String id) async => null;
+
+  @override
+  Future<Account> insert(Account account) async => account;
+
+  @override
+  Future<Account> update(Account account) async => account;
+
+  @override
+  Future<void> archive(String id) async {}
+
+  @override
+  Future<void> updateBalance(String id, int newBalance) async {}
+}
+
+class FakeCategoryRepository implements CategoryRepository {
+  @override
+  Future<List<Category>> getAll() async => [];
+
+  @override
+  Future<Category?> getById(String id) async => null;
+
+  @override
+  Future<Category> insert(Category category) async => category;
+
+  @override
+  Future<Category> update(Category category) async => category;
+
+  @override
+  Future<void> delete(String id) async {}
+}
+
+void main() {
+  late GenerateReport generateReport;
+  late List<Transaction> testTransactions;
+
+  setUp(() {
+    testTransactions = [
+      Transaction(
+        id: '1',
+        amount: 100,
+        type: TransactionType.expense,
+        categoryId: 'cat1',
+        accountId: 'acc1',
+        dateTime: DateTime(2024, 1, 1),
+      ),
+      Transaction(
+        id: '2',
+        amount: 200,
+        type: TransactionType.income,
+        categoryId: 'cat2',
+        accountId: 'acc2',
+        dateTime: DateTime(2024, 2, 1),
+      ),
+    ];
+
+    generateReport = GenerateReport(
+      reportRepository: FakeReportRepository(),
+      transactionRepository: FakeTransactionRepository(testTransactions),
+      accountRepository: FakeAccountRepository(),
+      categoryRepository: FakeCategoryRepository(),
+    );
+  });
+
+  test('should return pdf path and filter by date', () async {
+    final path = await generateReport(
+      type: 'pdf',
+      startDate: DateTime(2024, 1, 15),
+    );
+
+    expect(path, 'pdf_path');
+  });
+
+  test('should return excel path', () async {
+    final path = await generateReport(type: 'excel');
+    expect(path, 'excel_path');
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <share_plus/share_plus_windows_plugin_c_api.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  SharePlusWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,8 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  share_plus
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
## Overview
This PR implements the **Bank-Ready Reports** feature, allowing users to generate and export professional financial statements in PDF and Excel formats. The feature adheres to the app's **Stationery** design aesthetic and follows Clean Architecture principles.

## Changes
### 🏗️ Architecture & Domain
- Added `ReportRepository` and `GenerateReport` use case.
- Implemented filtering logic by Date Range and specific Account (Asset/Liability).

### 📄 Data Layer (Generation Services)
- **PDF Generation**: Created `PdfReportService` using the `pdf` package.
  - Custom themed output (Cream paper, Ink blue headers).
  - Integration of **Lora** (Serif) and **JetBrainsMono** (Numeric) fonts.
- **Excel Generation**: Created `ExcelReportService` for structured ledger spreadsheets.
- **Sharing**: Integrated `share_plus` to allow users to "Save to Files" or share via external apps.

### 🎨 Presentation Layer
- **ReportsScreen**: A functional interface for filtering and triggering exports.
- **ReportsProvider**: State management for report generation and file persistence.

## Verification
- **Unit Tests**: Passed `test/domain/usecases/generate_report_test.dart`.
- **Manual Check**:
  - Verified PDF layout (alignment, fonts, colors).
  - Verified Excel data structure.
  - Verified share sheet functionality on Android/iOS emulators.

## Note to Reviewers
> [!IMPORTANT]
> This feature introduces the `pdf`, `excel`, and `share_plus` dependencies. A full `flutter run` is required to link the new native plugins.

## Screenshots (Conceptual)
| Feature | Description |
| :--- | :--- |
| **Filter UI** | Period selection and Account dropdown |
| **PDF Statement** | High-fidelity stationery layout |
| **Share Sheet** | "Save to Files" / External App integration |
